### PR TITLE
fix tensorQTL bug

### DIFF
--- a/code/association_scan/TensorQTL/TensorQTL.ipynb
+++ b/code/association_scan/TensorQTL/TensorQTL.ipynb
@@ -818,8 +818,8 @@
     "[cis_2]\n",
     "done_if(\"regional\" not in _input.labels)\n",
     "input: group_by = \"all\"\n",
-    "output: f'{cwd}/{_input[\"regional\"]:bnnnn}.cis_qtl_regional.fdr.gz',\n",
-    "        f'{cwd}/{_input[\"regional\"]:bnnnn}.cis_qtl_regional.summary.txt'\n",
+    "output: f'{cwd}/{_input[\"regional\"][0]:bnnnnn}.cis_qtl_regional.fdr.gz',\n",
+    "        f'{cwd}/{_input[\"regional\"][0]:bnnnnn}.cis_qtl_regional.summary.txt'\n",
     "input_files = [str(x) for x in _input[\"regional\"]]\n",
     "task: trunk_workers = 1, trunk_size = job_size, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output[0]:bn}'\n",
     "python: expand= \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout',container = container, entrypoint = entrypoint\n",
@@ -1030,7 +1030,7 @@
      "sos"
     ]
    ],
-   "version": "0.23.4"
+   "version": "0.24.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the previouse version, when using the genotype data from rosmap, there output for cis_2 will be a list of 22 chr genotype file connected by a space and produce an error. 

I don't believed this in intended so I fix that.