### PR TITLE
Sync YAML and README examples

### DIFF
--- a/code/SoS/xqtl_modifier_score/data_config.yaml
+++ b/code/SoS/xqtl_modifier_score/data_config.yaml
@@ -2,7 +2,7 @@
 feature_data:
   gene_constraint:
     name: "gene_lof"
-    file_path: "../../data/41588_2024_1820_MOESM4_ESM.xlsx"
+    file_path: "../../input/xqtl_modifier_score/protocol_example.gene_constraint.xlsx"
     xlsx_sheet: "Supplementary Table 1"
     include_columns: ["ensg", "post_mean"]
     column_mapping:
@@ -15,22 +15,22 @@ feature_data:
 
   population_genetics:
     name: "maf"
-    file_pattern: "../../data/gnomad_MAF_chr{chromosome}.tsv"
+    file_pattern: "../../input/xqtl_modifier_score/protocol_example.gnomad_MAF_chr{chromosome}.tsv"
     column_mapping:
       variant_id: "variant_id"
       target_value: "gnomad_MAF"
 
   distance_features:
-    columns_dict_file: "data/columns_dict.pkl"
+    columns_dict_file: "../../input/xqtl_modifier_score/protocol_example.columns_dict.pkl"
     subset_keys: ["distance"]
     columns_to_remove: ["abs_distance_TSS", "distance_TSS"]
 
   regulatory_features:
-    columns_dict_file: "data/columns_dict.pkl"
+    columns_dict_file: "../../input/xqtl_modifier_score/protocol_example.columns_dict.pkl"
     subset_keys: ["ABC", "celltype", "baseline"]
 
   deep_learning_features:
-    columns_dict_file: "data/columns_dict.pkl"
+    columns_dict_file: "../../input/xqtl_modifier_score/protocol_example.columns_dict.pkl"
     subset_keys: ["chrombpnet_positive", "diff", "tf_positive"]
     transformations:
       absolute_value: ["diff", "tf_positive", "chrombpnet_positive"]
@@ -39,13 +39,13 @@ feature_data:
     generated_columns: ["length_diff", "is_SNP", "is_indel", "is_insertion", "is_deletion", "gene_lof", "gnomad_MAF"]
 
 training_data:
-  base_dir: "../../data/{cohort}/training_data"
+  base_dir: "../../input/xqtl_modifier_score/{cohort}/training_data"
   file_pattern: "annotated_data_{cohort}_{chromosome}.parquet"
   train_dir_pattern: "train_NPR_{npr_tr}_PIP_{pos_threshold}_{neg_threshold}"
   test_dir_pattern: "test_NPR_{npr_te}_PIP_{pos_threshold}_{neg_threshold}"
   metadata_columns: ["variant_id", "pip", "CHR", "BP", "REF", "ALT", "SNP", "label", "weight"]
 
 output:
-  base_dir: "../../data/{cohort}/model_results"
+  base_dir: "../../output/xqtl_modifier_score/{cohort}/model_results"
   predictions_dir: "predictions_parquet_catboost"
 

--- a/code/SoS/xqtl_modifier_score/model_config.yaml
+++ b/code/SoS/xqtl_modifier_score/model_config.yaml
@@ -1,78 +1,35 @@
+# Toy model configuration for EMS training/prediction MWE
+system:
+  temp_directory: "/tmp/ems_dask"
+  random_seeds:
+    torch_seed: 0
+    numpy_seed: 0
+    random_seed: 0
 
-# Generic Model Configuration - User Customizable
-algorithm:
-  name: "catboost"
-  parameter_sets:
-    standard:
-      depth: 4
-      iterations: 20
-      learning_rate: 0.05
-      l2_leaf_reg: 3.0
-      min_data_in_leaf: 10
-      verbose: true
-      loss_function: "Logloss"
-      
-    conservative:
-      depth: 5
-      iterations: 100
-      learning_rate: 0.03
-      l2_leaf_reg: 5.0
-      min_data_in_leaf: 10
-      bagging_temperature: 1.0
-      leaf_estimation_method: "Newton"
-      leaf_estimation_iterations: 10
-      verbose: true
-      loss_function: "Logloss"
+experiment:
+  sampling_parameters:
+    npr_train: 1
+    npr_test: 1
+  classification_thresholds:
+    train:
+      positive_class_threshold: 0.5
+      negative_class_threshold: 0.1
+    test:
+      positive_class_threshold: 0.5
+      negative_class_threshold: 0.1
 
 feature_weighting:
   default_weight: 1.0
   high_priority_patterns:
-    weight: 10.0
-    feature_patterns: ["chrombpnet_positive", "tf_positive", "diff"]
+    weight: 2.0
+    feature_patterns: ["ABC", "chrombpnet"]
 
-model_variants:
-  baseline:
-    name: "Standard"
-    description: "Standard parameters, no feature weighting"
-    parameter_set: "standard"
-    use_feature_weights: false
-    
-  regularized:
-    name: "Conservative"
-    description: "Conservative parameters to reduce overfitting"
-    parameter_set: "conservative"
-    use_feature_weights: false
-    
-  weighted:
-    name: "Feature-Weighted"
-    description: "Standard parameters with biology-informed weighting"
-    parameter_set: "standard"
-    use_feature_weights: true
-    
-  regularized_weighted:
-    name: "Conservative-Weighted"
-    description: "Conservative parameters with feature weighting"
-    parameter_set: "conservative"
-    use_feature_weights: true
-
-training:
-  evaluation_metrics: ["average_precision_score", "roc_auc_score"]
-
-experiment:
-  sampling_parameters:
-    npr_train: 10
-    npr_test: 10
-  classification_thresholds:
-    train:
-      positive_class_threshold: 0.1
-      negative_class_threshold: 0.01
-    test:
-      positive_class_threshold: 0.9
-      negative_class_threshold: 0.01
-
-system:
-  temp_directory: "/nfs/scratch"
-  random_seeds:
-    torch_seed: 9448
-    numpy_seed: 9448
-    random_seed: 9448
+algorithm:
+  parameter_sets:
+    standard:
+      iterations: 50
+      depth: 4
+      learning_rate: 0.1
+      loss_function: "Logloss"
+      verbose: 0
+      random_seed: 0

--- a/code/snakemake/config.yaml
+++ b/code/snakemake/config.yaml
@@ -30,9 +30,9 @@ pipeline_dir: "/sc/arion/projects/load/users/sunh14/xqtl/xqtl-protocol/pipeline"
 # ------------------------------------
 # Path to code/script directory
 # (contains standalone R/Python/Bash scripts)
-# Used by the modular-script Snakemake rules.
+# Used by: Snakefile_native (Version 2)
 # ------------------------------------
-modular_script_dir: "/sc/arion/projects/load/users/sunh14/xqtl/xqtl-protocol/code/script"
+renovated_code_dir: "/sc/arion/projects/load/users/sunh14/xqtl/xqtl-protocol/code/script"
 
 # ------------------------------------
 # Starting point of the pipeline

--- a/code/snakemake/dryrun/README.md
+++ b/code/snakemake/dryrun/README.md
@@ -29,17 +29,6 @@ The default live Pixi home used on this machine is outside the repository:
 ../xqtl-renovated/mwe_data/.pixi
 ```
 
-## MWE Data Provenance
-
-The full external MWE data tree was downloaded from:
-
-```bash
-s3://statfungen/ftp_fgc_xqtl/xqtl_protocol_data/mwe_data/
-```
-
-It is intentionally not committed to this repository. Point `--mwe-data` at a
-local copy of that tree, or at an archive containing that tree.
-
 ## Example
 
 From the repository root:


### PR DESCRIPTION
## Summary

- sync xqtl_modifier_score YAML example/config files from jaempawi/sync-sos-notebooks
- sync snakemake dryrun README from jaempawi/sync-sos-notebooks
- intentionally exclude notebooks and implementation files (.R/.py/.smk)

## Checks

- staged diff was limited to 3 YAML files and 1 README
- verified the selected files match jaempawi/sync-sos-notebooks exactly
