### PR TITLE
Extract remaining narrative example cells

### DIFF
--- a/code/SoS/association_scan/quantile_models/qr_and_twas.ipynb
+++ b/code/SoS/association_scan/quantile_models/qr_and_twas.ipynb
@@ -164,17 +164,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "zcat output/covariate/protocol_example.protein.protocol_example.samples.protocol_example.genotype.chr21_22.pQTL.plink_qc.prune.pca.Marchenko_PC.gz | head -1 | awk '{for (i=2; i<=51; i++) printf $i \" \"; print \"\"}'> output/keep_samples.txt"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"

--- a/code/SoS/data_preprocessing/genotype/VCF_QC.ipynb
+++ b/code/SoS/data_preprocessing/genotype/VCF_QC.ipynb
@@ -450,6 +450,17 @@
    },
    "outputs": [],
    "source": [
+    "grep Ts/Tv output/vcf_qc/protocol_example.genotype.chr1.leftnorm.novel_variant.snipsift_tstv | rev | cut -d',' -f1 | rev"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
     "# Handel multi-allelic sites, left normalization of indels and add variant ID\n",
     "[qc_1 (variant preprocessing)]\n",
     "# Path to dbSNP variants generated previously\n",
@@ -481,6 +492,17 @@
    },
    "source": [
     "For known variants: in this toy dataset the `known_variant` Ts/Tv files are usually empty because the example variants are not present in dbSNP."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "grep Ts/Tv output/vcf_qc/protocol_example.genotype.chr1.leftnorm.known_variant.snipsift_tstv | rev | cut -d',' -f1 | rev"
    ]
   },
   {
@@ -534,6 +556,17 @@
    },
    "source": [
     "To inspect novel-variant Ts/Tv on another chromosome (e.g. chr22):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "grep Ts/Tv output/vcf_qc/protocol_example.genotype.chr22.leftnorm.novel_variant.snipsift_tstv | rev | cut -d',' -f1 | rev"
    ]
   },
   {

--- a/code/SoS/enrichment/sldsc_enrichment.ipynb
+++ b/code/SoS/enrichment/sldsc_enrichment.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "Minimal working-example driver for the S-LDSC functional-enrichment pipeline. The **Steps** section below gives one ready-to-run `sos run` command per workflow, using the toy inputs symlinked under `input/`.\n",
     "\n",
-    "> **Environment note.** Steps 1–2 (`make_annotation_files_ldscore`, `get_heritability`) wrap the external **polyfun** toolkit (`compute_ldscores.py`, `ldsc.py`, `munge_polyfun_sumstats.py`) and require pre-computed reference-panel files (baseline-LD scores, LD weights, `.frq`, and PLINK `.bed/.bim/.fam`). polyfun is **not installed in this environment** and the reference panel is not shipped with the toy example, so those two steps cannot be executed here; their commands are provided for use on a system where polyfun and a matching panel are available. Steps 3–4 (`postprocess`, `meta_subset`) use `pecotmr::sldsc_postprocessing_pipeline` (available here) and read the `.results`/`.log` files produced by Step 2.\n"
+    "> **Environment note.** Steps 1\u20132 (`make_annotation_files_ldscore`, `get_heritability`) wrap the external **polyfun** toolkit (`compute_ldscores.py`, `ldsc.py`, `munge_polyfun_sumstats.py`) and require pre-computed reference-panel files (baseline-LD scores, LD weights, `.frq`, and PLINK `.bed/.bim/.fam`). polyfun is **not installed in this environment** and the reference panel is not shipped with the toy example, so those two steps cannot be executed here; their commands are provided for use on a system where polyfun and a matching panel are available. Steps 3\u20134 (`postprocess`, `meta_subset`) use `pecotmr::sldsc_postprocessing_pipeline` (available here) and read the `.results`/`.log` files produced by Step 2.\n"
    ]
   },
   {
@@ -101,8 +101,8 @@
     "\n",
     "The pipeline has two computational layers:\n",
     "\n",
-    "- **Regression layer** — the S-LDSC regression itself, performed by the [polyfun](https://github.com/omerwe/polyfun) engine. We do not re-implement this.\n",
-    "- **Post-processing layer** — standardization, differential per-SNP heritability, binary/continuous detection, and random-effects meta-analysis across traits. Implemented in the [`pecotmr`](https://github.com/StatFunGen/pecotmr) R package (`R/sldsc_wrapper.R`).\n",
+    "- **Regression layer** \u2014 the S-LDSC regression itself, performed by the [polyfun](https://github.com/omerwe/polyfun) engine. We do not re-implement this.\n",
+    "- **Post-processing layer** \u2014 standardization, differential per-SNP heritability, binary/continuous detection, and random-effects meta-analysis across traits. Implemented in the [`pecotmr`](https://github.com/StatFunGen/pecotmr) R package (`R/sldsc_wrapper.R`).\n",
     "\n",
     "The notation below tags each modeling quantity as **(polyfun)** or **(pecotmr)**.\n",
     "\n",
@@ -115,7 +115,7 @@
     "\n",
     "#### Reference panel and MAF cutoff\n",
     "\n",
-    "All LD-derived quantities — partitioned LD scores for the 97 baseline annotations and for our $K$ target annotations, the LD-score-regression weights, allele frequencies, and the SNP set — are computed against our own LD reference panel. We do not mix in pre-computed quantities from external panels (e.g. 1000G); $M_{\\mathrm{ref}}$ throughout this notebook denotes the number of common SNPs in our panel.\n",
+    "All LD-derived quantities \u2014 partitioned LD scores for the 97 baseline annotations and for our $K$ target annotations, the LD-score-regression weights, allele frequencies, and the SNP set \u2014 are computed against our own LD reference panel. We do not mix in pre-computed quantities from external panels (e.g. 1000G); $M_{\\mathrm{ref}}$ throughout this notebook denotes the number of common SNPs in our panel.\n",
     "\n",
     "By default we restrict to MAF $> 5\\%$ per the sLDSC recommendation: rare-variant LD is unstable and HapMap3-style regression weights are common-variant by construction. The cutoff is exposed as the SoS parameter `maf_cutoff` (default $0.05$); the regression, the standardized $sd_C$, and $M_{\\mathrm{ref}}$ are all evaluated on the same MAF $>$ cutoff SNP set. If allele-frequency files are not available the pipeline fails; the user must explicitly set `maf_cutoff = 0` to opt out (not recommended).\n",
     "\n",
@@ -123,30 +123,30 @@
     "\n",
     "Solving Equation (2) jointly across annotations, with 200-block genomic jackknife for inference, is performed by polyfun's `ldsc.py`. From each polyfun run we obtain, per annotation:\n",
     "\n",
-    "- $\\tau_C$ and its standard error — **(polyfun)**.\n",
-    "- $\\pi^{h^2}_C$ and $\\pi^{M}_C$ — **(polyfun)**.\n",
-    "- $E_C = \\pi^{h^2}_C / \\pi^{M}_C$ and its standard error — **(polyfun)**.\n",
-    "- The p-value of the differential per-SNP heritability test (defined below) — **(polyfun)**, computed internally with the full coefficient covariance matrix.\n",
+    "- $\\tau_C$ and its standard error \u2014 **(polyfun)**.\n",
+    "- $\\pi^{h^2}_C$ and $\\pi^{M}_C$ \u2014 **(polyfun)**.\n",
+    "- $E_C = \\pi^{h^2}_C / \\pi^{M}_C$ and its standard error \u2014 **(polyfun)**.\n",
+    "- The p-value of the differential per-SNP heritability test (defined below) \u2014 **(polyfun)**, computed internally with the full coefficient covariance matrix.\n",
     "\n",
     "We also obtain, per run:\n",
     "\n",
-    "- The total trait heritability $h^2_g$ — **(polyfun)**.\n",
-    "- The 200-block jackknife delete-values of $\\tau_C$ — **(polyfun)**.\n",
+    "- The total trait heritability $h^2_g$ \u2014 **(polyfun)**.\n",
+    "- The 200-block jackknife delete-values of $\\tau_C$ \u2014 **(polyfun)**.\n",
     "\n",
     "#### Quantities from the post-processing layer (pecotmr)\n",
     "\n",
     "From the polyfun outputs above plus our reference panel, the post-processing layer computes:\n",
     "\n",
-    "- $sd_C$ — per-annotation standard deviation over MAF $>$ cutoff SNPs — **(pecotmr: `compute_sldsc_annot_sd`)**.\n",
-    "- $M_{\\mathrm{ref}}$ — reference SNP count at the MAF cutoff — **(pecotmr: `compute_sldsc_M_ref`)**.\n",
-    "- Whether each annotation is binary or continuous — **(pecotmr: `is_binary_sldsc_annot`)**.\n",
-    "- $\\tau^*_C$ point estimate and per-block $\\tau^*_C$ — **(pecotmr: `standardize_sldsc_trait`)**.\n",
-    "- EnrichStat point estimate and its standard error (formula below) — **(pecotmr: `standardize_sldsc_trait`)**.\n",
-    "- DerSimonian-Laird random-effects meta-analysis of $\\tau^*_C$, $E_C$, or EnrichStat across traits — **(pecotmr: `meta_sldsc_random`)**.\n",
+    "- $sd_C$ \u2014 per-annotation standard deviation over MAF $>$ cutoff SNPs \u2014 **(pecotmr: `compute_sldsc_annot_sd`)**.\n",
+    "- $M_{\\mathrm{ref}}$ \u2014 reference SNP count at the MAF cutoff \u2014 **(pecotmr: `compute_sldsc_M_ref`)**.\n",
+    "- Whether each annotation is binary or continuous \u2014 **(pecotmr: `is_binary_sldsc_annot`)**.\n",
+    "- $\\tau^*_C$ point estimate and per-block $\\tau^*_C$ \u2014 **(pecotmr: `standardize_sldsc_trait`)**.\n",
+    "- EnrichStat point estimate and its standard error (formula below) \u2014 **(pecotmr: `standardize_sldsc_trait`)**.\n",
+    "- DerSimonian-Laird random-effects meta-analysis of $\\tau^*_C$, $E_C$, or EnrichStat across traits \u2014 **(pecotmr: `meta_sldsc_random`)**.\n",
     "\n",
     "The top-level entry point `pecotmr::sldsc_postprocessing_pipeline` orchestrates all of the above.\n",
     "\n",
-    "#### Standardized tau ($\\tau^*$)  —  (pecotmr)\n",
+    "#### Standardized tau ($\\tau^*$)  \u2014  (pecotmr)\n",
     "\n",
     "$\\tau_C$ has units that depend on the scale of the annotation and on the total heritability of the trait, so raw $\\tau$ is not directly comparable across annotations or across traits. We compute the standardized version (Gazal et al. 2017)\n",
     "\n",
@@ -158,7 +158,7 @@
     "$$SE^{\\text{jackknife}}(\\tau^*_C) \\;=\\; \\sqrt{\\,\\tfrac{(B-1)^2}{B}\\, \\mathrm{Var}_b(\\tau^*_{C,(b)})\\,}$$\n",
     "with $B = 200$, used as the per-trait input to cross-trait meta-analysis.\n",
     "\n",
-    "#### Differential per-SNP heritability (\"EnrichStat\")  —  (polyfun + pecotmr)\n",
+    "#### Differential per-SNP heritability (\"EnrichStat\")  \u2014  (polyfun + pecotmr)\n",
     "\n",
     "To test whether the per-SNP heritability *inside* annotation $C$ differs from *outside* it (Finucane et al. 2015):\n",
     "\n",
@@ -170,7 +170,7 @@
     "\n",
     "This per-trait point + SE is the input to cross-trait meta-analysis.\n",
     "\n",
-    "#### Reporting: binary vs. continuous annotations  —  (pecotmr)\n",
+    "#### Reporting: binary vs. continuous annotations  \u2014  (pecotmr)\n",
     "\n",
     "The estimation machinery applies to both annotation types, but the *headline* quantity to report **within each type** differs.\n",
     "\n",
@@ -186,17 +186,17 @@
     ">\n",
     "> The pipeline always passes `--print-coefficients` to polyfun for this reason.\n",
     "\n",
-    "#### Cross-type comparison: always use $\\tau^*_C$  —  (pecotmr)\n",
+    "#### Cross-type comparison: always use $\\tau^*_C$  \u2014  (pecotmr)\n",
     "\n",
-    "For an apple-to-apple comparison **across binary and continuous annotations** — ranking annotations on a single axis, meta-analyzing a mixed set, or reporting a leaderboard that pools both types — use $\\tau^*_C$. The standardization in Gazal et al. (2017) was designed for exactly this purpose: $sd_C = \\sqrt{p(1-p)}$ for a binary annotation (where $p$ is the proportion in the category) and $sd_C = $ empirical standard deviation for a continuous annotation, so the resulting $\\tau^*_C$ is dimensionless and has the same interpretation in both cases — additive change in per-SNP heritability per 1 SD increase in the annotation, normalized by the average per-SNP heritability. $E_C$ does not have this property and must not be compared across types.\n",
+    "For an apple-to-apple comparison **across binary and continuous annotations** \u2014 ranking annotations on a single axis, meta-analyzing a mixed set, or reporting a leaderboard that pools both types \u2014 use $\\tau^*_C$. The standardization in Gazal et al. (2017) was designed for exactly this purpose: $sd_C = \\sqrt{p(1-p)}$ for a binary annotation (where $p$ is the proportion in the category) and $sd_C = $ empirical standard deviation for a continuous annotation, so the resulting $\\tau^*_C$ is dimensionless and has the same interpretation in both cases \u2014 additive change in per-SNP heritability per 1 SD increase in the annotation, normalized by the average per-SNP heritability. $E_C$ does not have this property and must not be compared across types.\n",
     "\n",
     "The pipeline emits both $E_C$ and $\\tau^*_C$ for every annotation, with the binary/continuous flag, so callers can pick the right column for the comparison they are making.\n",
     "\n",
-    "#### Joint analysis  —  (polyfun runs the regression; pecotmr standardizes both modes)\n",
+    "#### Joint analysis  \u2014  (polyfun runs the regression; pecotmr standardizes both modes)\n",
     "\n",
     "For **joint analysis** (multiple annotations fit together), both $\\tau$ and $E$ are conditional on the other annotations in the model. We report joint $\\tau^*_C$ as the independent contribution of annotation $C$ after controlling for the others. The annotation-prep step exposes two independent toggles, `compute_single` and `compute_joint` (both default `True`), so the user can produce the $N$ single-target outputs, the joint output, or both in one invocation. With both defaults the post-processing layer reads all $N+1$ regression outputs per trait and presents single + joint side-by-side. When the joint subset is decided after looking at single-target results (exploratory $\\rightarrow$ conditional workflow), the user runs the annotation-prep step a second time with `compute_single=False` on the curated subset.\n",
     "\n",
-    "### Meta-Analysis across Traits (Random Effects)  —  (pecotmr)\n",
+    "### Meta-Analysis across Traits (Random Effects)  \u2014  (pecotmr)\n",
     "\n",
     "DerSimonian-Laird random-effects meta-analysis of per-annotation estimates across traits, implemented in `pecotmr::meta_sldsc_random` (which delegates the numerics to `rmeta::meta.summaries(..., method = \"random\")`):\n",
     "\n",
@@ -321,10 +321,10 @@
     "\n",
     "Each workflow writes into its `--cwd`:\n",
     "\n",
-    "- **make_annotation_files_ldscore** — polyfun `.annot.gz` files plus per-annotation LD-score directories (`.l2.ldscore.{gz,parquet}`, `.l2.M`, `.l2.M_5_50`). One single-target directory per annotation, plus (when more than one annotation) a joint directory.\n",
-    "- **get_heritability** — per trait and per target directory, the S-LDSC regression outputs `<trait>.{results,log,part_delete}`. The `.results` `Category` column carries the annotation name with a `_<ref-ld-index>` suffix.\n",
-    "- **postprocess** — a single `<annotation_name>.sldsc_postprocess.rds` containing per-trait tables (Gazal-style tau*, EnrichStat with back-solved jackknife SE) and three DerSimonian–Laird random-effects meta tables (tau*, E, EnrichStat).\n",
-    "- **meta_subset** — a re-meta of the cached `.sldsc_postprocess.rds` over a user-defined trait subset (lightweight; no regression re-run).\n"
+    "- **make_annotation_files_ldscore** \u2014 polyfun `.annot.gz` files plus per-annotation LD-score directories (`.l2.ldscore.{gz,parquet}`, `.l2.M`, `.l2.M_5_50`). One single-target directory per annotation, plus (when more than one annotation) a joint directory.\n",
+    "- **get_heritability** \u2014 per trait and per target directory, the S-LDSC regression outputs `<trait>.{results,log,part_delete}`. The `.results` `Category` column carries the annotation name with a `_<ref-ld-index>` suffix.\n",
+    "- **postprocess** \u2014 a single `<annotation_name>.sldsc_postprocess.rds` containing per-trait tables (Gazal-style tau*, EnrichStat with back-solved jackknife SE) and three DerSimonian\u2013Laird random-effects meta tables (tau*, E, EnrichStat).\n",
+    "- **meta_subset** \u2014 a re-meta of the cached `.sldsc_postprocess.rds` over a user-defined trait subset (lightweight; no regression re-run).\n"
    ]
   },
   {
@@ -378,28 +378,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    " # case 1: txt file as input\n",
-    " sos run pipeline/sldsc_enrichment.ipynb make_annotation_files_ldscore \\\n",
-    "    --annotation_file data/polyfun/input/colocboost_test_annotation_path.txt \\\n",
-    "    --reference_anno_file data/polyfun/input/reference_annotation0.txt \\\n",
-    "    --genome_ref_file data/polyfun/input/genome_reference_bfile.txt \\\n",
-    "    --annotation_name test_colocboost \\\n",
-    "    --plink_name reference. \\\n",
-    "    --baseline_name annotations. \\\n",
-    "    --weight_name weights. \\\n",
-    "    --python_exec python \\\n",
-    "    --polyfun_path data/github/polyfun \\\n",
-    "    --cwd output/polyfun/ -j 22"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -435,28 +413,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "# single file format\n",
-    " sos run pipeline/sldsc_enrichment.ipynb make_annotation_files_ldscore \\\n",
-    "    --annotation_file data/polyfun/input/colocboost_test.tsv \\\n",
-    "    --reference_anno_file data/polyfun/example_annot0/annotations.1.annot.gz \\\n",
-    "    --genome_ref_file data/polyfun/example_data/reference.1.bed \\\n",
-    "    --annotation_name test_colocboost \\\n",
-    "    --plink_name reference. \\\n",
-    "    --baseline_name annotations. \\\n",
-    "    --weight_name weights. \\\n",
-    "    --python_exec python \\\n",
-    "    --polyfun_path data/github/polyfun \\\n",
-    "    --cwd output/polyfun/ --chromosome 1"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -489,32 +445,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "# Annotation prep: an annotation_file with multiple `path*` columns yields\n",
-    "# N single-target output directories plus 1 joint directory in one call.\n",
-    "# To do Workflow B step 1 (singles only), pass --no-compute-joint.\n",
-    "# To do Workflow B step 2 (joint only on a curated subset), pass --no-compute-single\n",
-    "# with a new annotation_file containing just the curated annotations.\n",
-    "sos run pipeline/sldsc_enrichment.ipynb make_annotation_files_ldscore \\\n",
-    "    --annotation_file data/quantile_qtl_annotation/AC_DeJager_eQTL.multi_target_example.txt \\\n",
-    "    --reference_anno_file data/reference_annotation.txt \\\n",
-    "    --genome_ref_file data/genome_reference_bfile.txt \\\n",
-    "    --snp_list data/1000G_EUR_Phase3_hg38/list.txt \\\n",
-    "    --annotation_name my_analysis \\\n",
-    "    --cwd output \\\n",
-    "    --chromosome 1\n",
-    "# Produces (with defaults: compute_single=TRUE, compute_joint=TRUE):\n",
-    "#   output/my_analysis_single_1/  ...  output/my_analysis_single_N/   (compute_single)\n",
-    "#   output/my_analysis_joint/                                          (compute_joint, N>=2)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -522,7 +452,7 @@
    "source": [
     "**Step 4.** Optional: re-run the random-effects meta-analysis on a trait subset (`meta_subset`).\n",
     "\n",
-    "Reuses the cached `.sldsc_postprocess.rds` from Step 3 — no regression re-computation."
+    "Reuses the cached `.sldsc_postprocess.rds` from Step 3 \u2014 no regression re-computation."
    ]
   },
   {
@@ -543,26 +473,6 @@
     "    --polyfun_path data/github/polyfun \\\n",
     "    --maf_cutoff 0 \\\n",
     "    --cwd output/sldsc_postprocess -j 4"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "# Direct file-path mode: comma-separated annotation files (single-chromosome run).\n",
-    "# Same toggle semantics: compute_single (default TRUE) and compute_joint (default TRUE).\n",
-    "sos run pipeline/sldsc_enrichment.ipynb make_annotation_files_ldscore \\\n",
-    "    --annotation_file data/AC_DeJager_eQTL.unique_qr.rds,data/AC_DeJager_eQTL.shared_homo.rds \\\n",
-    "    --reference_anno_file data/example_anno/ABC_Road_GI_BRN.1.annot.gz \\\n",
-    "    --genome_ref_file data/plink_files/1000G.EUR.hg38.1.bed \\\n",
-    "    --snp_list data/1000G_EUR_Phase3_hg38/list.txt \\\n",
-    "    --annotation_name my_analysis \\\n",
-    "    --cwd output/mwe \\\n",
-    "    --chromosome 1"
    ]
   },
   {
@@ -599,33 +509,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "# Run polyfun across all (trait, target_dir) pairs in one invocation.\n",
-    "# target_anno_dirs is the list of output dirs from [make_annotation_files_ldscore]:\n",
-    "# the N single-target dirs plus optionally the joint dir.\n",
-    "sos run pipeline/sldsc_enrichment.ipynb get_heritability \\\n",
-    "    --target-anno-dirs output/my_analysis_single_1 output/my_analysis_single_2 output/my_analysis_joint \\\n",
-    "    --all-traits-file data/all_traits.txt \\\n",
-    "    --sumstat-dir data/sumstats \\\n",
-    "    --baseline-ld-dir data/baselineLD_v2.2_ADSP \\\n",
-    "    --frqfile-dir data/ADSP/frq \\\n",
-    "    --weights-dir data/ADSP_weights \\\n",
-    "    --plink-name ADSP_chr \\\n",
-    "    --baseline-name baseline_chr \\\n",
-    "    --weight-name weights_chr \\\n",
-    "    --annotation-name my_analysis \\\n",
-    "    --cwd output/heritability \\\n",
-    "    --maf-cutoff 0.05\n",
-    "# (allm variant: use --maf-cutoff 0 — no MAF filter; polyfun then uses --not-M-5-50)\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -634,77 +517,6 @@
     "## Workflow implementation\n",
     "\n",
     "The cells below are the pipeline definition (preserved from the original notebook): the `[global]` parameter block and the workflow step bodies.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": [
-    "# Post-processing: read all polyfun outputs (single-target + joint, all traits)\n",
-    "# under heritability_cwd and run the default meta-analysis via\n",
-    "# pecotmr::sldsc_postprocessing_pipeline. Single and joint target subdirectories\n",
-    "# are auto-detected from <annotation_name>_single_<i> and <annotation_name>_joint.\n",
-    "\n",
-    "# --target-categories: the joint-run target columns as they appear in the .results \"Category\"\n",
-    "#   column. The 2-target joint dir here has columns ANNOT_1, ANNOT_2 (compute_ldscores.py keeps\n",
-    "#   the annot col names) and polyfun appends \"_0\" (target = ref-ld file 0) -> \"ANNOT_1_0\", \"ANNOT_2_0\".\n",
-    "#   (Single-target dirs would be \"ANNOT_0\"; with --snp_list/ldsc.py and a single annot it is \"L2_0\".)\n",
-    "#   You can drop --target-categories entirely to auto-detect from the joint-run results.\n",
-    "# --target-categories-label (optional, same order as --target-categories): friendly display\n",
-    "#   names; renames the \"target\" column in the output (originals kept in params$target_categories_orig).\n",
-    "sos run pipeline/sldsc_enrichment.ipynb postprocess \\\n",
-    "    --traits-file data/all_traits.txt \\\n",
-    "    --heritability-cwd output/heritability \\\n",
-    "    --target-categories ANNOT_1_0 ANNOT_2_0 \\\n",
-    "    --target-categories-label quantile_eQTL eQTL \\\n",
-    "    --target-anno-dir output/my_analysis_joint \\\n",
-    "    --frqfile-dir data/ADSP/frq \\\n",
-    "    --plink-name ADSP_chr \\\n",
-    "    --annotation-name my_analysis \\\n",
-    "    --cwd output/sldsc_postprocess \\\n",
-    "    --maf-cutoff 0.05\n",
-    "# (allm variant: use --maf-cutoff 0 — no MAF filter; polyfun then uses --not-M-5-50)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "Python 3 (ipykernel)"
-   },
-   "source": [
-    "## Make Annotation File"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": [
-    "# Re-run random-effects meta on a subset of traits without recomputing the regression layer.\n",
-    "\n",
-    "sos run pipeline/sldsc_enrichment.ipynb meta_subset \\\n",
-    "    --postprocess-rds output/sldsc_postprocess/my_analysis.sldsc_postprocess.rds \\\n",
-    "    --subset-traits-file data/neuro_traits.txt \\\n",
-    "    --subset-name neuro \\\n",
-    "    --target-categories ANNOT_1_0 ANNOT_2_0 \\\n",
-    "    --annotation-name my_analysis \\\n",
-    "    --cwd output/sldsc_postprocess"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "## Munge Summary Statistics"
    ]
   },
   {
@@ -767,7 +579,7 @@
     "kernel": "Python 3 (ipykernel)"
    },
    "source": [
-    "## Calculate Functional Enrichment using Annotations"
+    "## Make Annotation File"
    ]
   },
   {
@@ -1170,6 +982,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Munge Summary Statistics"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -1198,6 +1019,15 @@
     "        {'--chi2-cutoff {}'.format(chi2_cut)} \\\n",
     "        {'--keep-hla' if keep_hla else ''} \\\n",
     "        --remove-strand-ambig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "Python 3 (ipykernel)"
+   },
+   "source": [
+    "## Calculate Functional Enrichment using Annotations"
    ]
   },
   {
@@ -1230,7 +1060,7 @@
     "#     index 1 = the baseline file -> \"base_1\",\"Coding_UCSC_1\", ...  (the 97 baseline annots)\n",
     "# So in this pipeline the suffix is only ever 0 (target) or 1 (baseline); it would\n",
     "# continue 0,1,2,... only if you handed `ldsc.py --ref-ld-chr` more than two sources.\n",
-    "# (Why ANNOT_0 vs L2_0: see the [make_annotation_files_ldscore] header — ldsc.py's\n",
+    "# (Why ANNOT_0 vs L2_0: see the [make_annotation_files_ldscore] header \u2014 ldsc.py's\n",
     "#  \"n_annot == 1 -> column name 'L2'\" quirk vs compute_ldscores.py keeping the annot\n",
     "#  column name.)  [postprocess] auto-detects the target Category; if you instead pass\n",
     "# --target-categories, the names must match this column exactly.\n",

--- a/code/SoS/mnm_analysis/mnm_methods/colocboost.ipynb
+++ b/code/SoS/mnm_analysis/mnm_methods/colocboost.ipynb
@@ -163,6 +163,29 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "SoS",
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# VERIFIED end-to-end on the toy gene-expression data (run from the toy_example root).\n",
+    "# xQTL-only ColocBoost on a single gene region. Produces *.cb_xqtl.rds.\n",
+    "sos run pipeline/colocboost.ipynb colocboost \\\n",
+    "    --name colocboost_xqtl --cwd output/colocboost_xqtl \\\n",
+    "    --genoFile input_geneexpr/example.chr22.bed \\\n",
+    "    --phenoFile input_geneexpr/pheno_manifest_1gene.tsv \\\n",
+    "    --covFile input_geneexpr/example_covariates.tsv \\\n",
+    "    --customized-association-windows input_geneexpr/association_windows_1gene.bed \\\n",
+    "    --region-name ENSG00000130538 \\\n",
+    "    --no-separate-gwas --xqtl-coloc -j1"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -171,6 +194,30 @@
     "### **Step 2.** ColocBoost with GWAS\n",
     "\n",
     "Adds GWAS summary statistics (via `--gwas-meta-data`) and an LD reference (via `--ld-meta-data`). The xQTL ColocBoost completes, but the separate GWAS-xQTL colocalization is **still under development** with the installed package (see the note in the command cell)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "# Partially runnable on the toy data (run from the toy_example root).\n",
+    "# The xQTL ColocBoost completes and writes *.cb_xqtl.rds, but the separate GWAS-xQTL\n",
+    "# colocalization step is STILL UNDER DEVELOPMENT: the installed ColocBoost errors with\n",
+    "# \"Separate GWAS ColocBoost ... failed: unused argument (X_ref = ...)\".\n",
+    "sos run pipeline/colocboost.ipynb colocboost \\\n",
+    "    --name colocboost_gwas --cwd output/colocboost_gwas \\\n",
+    "    --genoFile input_geneexpr/example.chr22.bed \\\n",
+    "    --phenoFile input_geneexpr/pheno_manifest_1gene.tsv \\\n",
+    "    --covFile input_geneexpr/example_covariates.tsv \\\n",
+    "    --customized-association-windows input_geneexpr/association_windows_1gene.bed \\\n",
+    "    --gwas-meta-data input_colocboost/gwas_meta.tsv \\\n",
+    "    --ld-meta-data data/input/data/LD_sketch/meta.tsv \\\n",
+    "    --region-name ENSG00000130538 \\\n",
+    "    --separate-gwas --xqtl-coloc -j1"
    ]
   },
   {
@@ -192,19 +239,20 @@
    },
    "outputs": [],
    "source": [
-    "# Multi-ancestry: per-study LD reference specified in gwas_meta_multi.tsv\n",
+    "# Still under development on the toy dataset.\n",
+    "# Multi-ancestry uses the per-study LD reference given in the gwas meta-data\n",
+    "# ld_meta_data column. It relies on the same separate-GWAS ColocBoost code path as\n",
+    "# Step 2, so it is currently blocked by the same package issue. Command template:\n",
     "sos run pipeline/colocboost.ipynb colocboost \\\n",
-    "    --name colocboost_multi_ld \\\n",
-    "    --cwd output/colocboost_multi_ld \\\n",
-    "    --genoFile output/plink/wgs.merged.bed \\\n",
-    "    --phenoFile output/phenotype/pheno.bed.gz \\\n",
-    "    --covFile output/covariate/cov.gz \\\n",
-    "    --customized-association-windows reference_data/TAD/TADB_enhanced_cis.bed \\\n",
-    "    --ld-meta-data reference_data/ld_EUR.tsv \\\n",
-    "    --gwas-meta-data data/colocboost/gwas_meta_multi.tsv \\\n",
-    "    --separate-gwas --xqtl-coloc \\\n",
-    "    --region-name ENSG00000239945 \\\n",
-    "    --phenotype-names trait_A\n"
+    "    --name colocboost_multi_ld --cwd output/colocboost_multi_ld \\\n",
+    "    --genoFile input_geneexpr/example.chr22.bed \\\n",
+    "    --phenoFile input_geneexpr/pheno_manifest_1gene.tsv \\\n",
+    "    --covFile input_geneexpr/example_covariates.tsv \\\n",
+    "    --customized-association-windows input_geneexpr/association_windows_1gene.bed \\\n",
+    "    --gwas-meta-data input_colocboost/gwas_meta.tsv \\\n",
+    "    --ld-meta-data data/input/data/LD_sketch/meta.tsv \\\n",
+    "    --region-name ENSG00000130538 \\\n",
+    "    --separate-gwas --xqtl-coloc -j1"
    ]
   },
   {

--- a/code/SoS/mnm_analysis/mnm_methods/mnm_regression.ipynb
+++ b/code/SoS/mnm_analysis/mnm_methods/mnm_regression.ipynb
@@ -104,6 +104,26 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "# Univariate fine-mapping (susie_twas) - VERIFIED end-to-end on the toy gene-expression data.\n",
+    "# Run from the toy_example root. --save-data writes univariate_data.rds, which supplies\n",
+    "# the combined_data_sumstats that the downstream mnm_genes workflow consumes.\n",
+    "sos run pipeline/mnm_regression.ipynb susie_twas \\\n",
+    "    --name test_uni --cwd output_uni \\\n",
+    "    --genoFile input_geneexpr/example.chr22.bed \\\n",
+    "    --phenoFile input_geneexpr/pheno_manifest.tsv \\\n",
+    "    --covFile input_geneexpr/example_covariates.tsv \\\n",
+    "    --customized-association-windows input_geneexpr/association_windows.bed \\\n",
+    "    --save-data -j1"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -789,6 +809,30 @@
    },
    "outputs": [],
    "source": [
+    "# Runs end-to-end on the toy dataset using a synthetic 2-context manifest.\n",
+    "# Notes for new users:\n",
+    "#  - mnm needs >=2 contexts; pheno_manifest_multicontext.tsv supplies context1 (real)\n",
+    "#    and context2 (example_geneexpr_ctx2.bed.gz, synthetic demo data).\n",
+    "#  - Use the gene-expression genotype (input_geneexpr/example.chr22.bed, sample IDs\n",
+    "#    SAMPLE_001..) so genotype and phenotype/covariate samples match.\n",
+    "#  - Requires the mr.mashr R package (provided by mr.mash.alpha in this env).\n",
+    "sos run pipeline/mnm_regression.ipynb mnm \\\n",
+    "    --name test_mnm --cwd output_mnm3 \\\n",
+    "    --genoFile input_geneexpr/example.chr22.bed \\\n",
+    "    --phenoFile input_geneexpr/pheno_manifest_multicontext.tsv \\\n",
+    "    --covFile input_geneexpr/example_covariates.tsv \\\n",
+    "    --customized-association-windows input_geneexpr/association_windows.bed \\\n",
+    "    --save-data -j1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "Bash"
+   },
+   "outputs": [],
+   "source": [
     "[mnm_genes]\n",
     "depends: sos_variable(\"regional_data\")\n",
     "# Check if both 'data' and 'meta_info' are empty lists\n",
@@ -1097,6 +1141,34 @@
    },
    "outputs": [],
    "source": [
+    "# Multi-gene / trans fine-mapping (mnm_genes) - VERIFIED end-to-end on the toy data.\n",
+    "# Run from the toy_example root. Requires:\n",
+    "#   --pheno_id_map_file : maps phenotype IDs across the two contexts\n",
+    "#   --fine_mapping_meta : per-region table pointing to the univariate (susie_twas, run above\n",
+    "#                         with --save-data) and multivariate (mnm) fine-mapping outputs\n",
+    "#   --keep-samples      : sample IDs to retain (matches the gene-expression genotype)\n",
+    "# On this toy set all regions return a NULL multigene_bvsr (no multi-gene/trans signal),\n",
+    "# which is the correct, honest result for independent single-gene toy regions.\n",
+    "sos run pipeline/mnm_regression.ipynb mnm_genes \\\n",
+    "    --name test_mnmgenes --cwd output_mnmgenes \\\n",
+    "    --genoFile input_geneexpr/example.chr22.bed \\\n",
+    "    --phenoFile input_geneexpr/pheno_manifest_multicontext.tsv \\\n",
+    "    --covFile input_geneexpr/example_covariates.tsv \\\n",
+    "    --customized-association-windows input_geneexpr/association_windows.bed \\\n",
+    "    --pheno_id_map_file input_geneexpr/pheno_id_map.tsv \\\n",
+    "    --fine_mapping_meta input_geneexpr/fine_mapping_meta.tsv \\\n",
+    "    --keep-samples input_geneexpr/keep_samples.txt \\\n",
+    "    --save-data -j1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "Bash"
+   },
+   "outputs": [],
+   "source": [
     "[fsusie]\n",
     "# prior can be either of [\"mixture_normal\", \"mixture_normal_per_scale\"]\n",
     "parameter: prior = \"mixture_normal\"\n",
@@ -1176,6 +1248,25 @@
    },
    "outputs": [],
    "source": [
+    "# Functional SuSiE (fsusie) - VERIFIED end-to-end on the toy peak data.\n",
+    "# Run from the toy_example root. Produces *.fsusie_mixture_normal_TI__top_pc_weights.rds.\n",
+    "sos run pipeline/mnm_regression.ipynb fsusie \\\n",
+    "    --name test_fsusie --cwd output/fsusie \\\n",
+    "    --genoFile input/genotype/protocol_example.genotype.chr22.bed \\\n",
+    "    --phenoFile input/phenotype/protocol_example.pheno_manifest.tsv \\\n",
+    "    --covFile input/covariate/protocol_example.covariates.tsv \\\n",
+    "    --customized-association-windows input/finemapping/protocol_example.association_windows.bed \\\n",
+    "    --cis-window 0 --max-cv-variants 5000 --save-data -j1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "Bash"
+   },
+   "outputs": [],
+   "source": [
     "[mvfsusie]\n",
     "# prior can be either of [\"mixture_normal\", \"mixture_normal_per_scale\"]\n",
     "parameter: prior  = \"mixture_normal_per_scale\"\n",
@@ -1218,6 +1309,25 @@
     "### Functional regression fSuSiE with other modality (`mvfsusie`)\n",
     "\n",
     "Multivariate functional SuSiE (mvfSuSiE). **Still under development** for the toy dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "Bash"
+   },
+   "outputs": [],
+   "source": [
+    "# Still under development on the toy dataset (the mvfSuSiE R step errors out).\n",
+    "# Command template:\n",
+    "sos run pipeline/mnm_regression.ipynb mvfsusie \\\n",
+    "    --name test_mvfsusie --cwd output/mvfsusie \\\n",
+    "    --genoFile input/genotype/protocol_example.genotype.chr22.bed \\\n",
+    "    --phenoFile input/phenotype/protocol_example.pheno_manifest.tsv \\\n",
+    "    --covFile input/covariate/protocol_example.covariates.tsv \\\n",
+    "    --customized-association-windows input/finemapping/protocol_example.association_windows.bed \\\n",
+    "    --save-data -j1"
    ]
   },
   {

--- a/code/SoS/mnm_analysis/mnm_postprocessing.ipynb
+++ b/code/SoS/mnm_analysis/mnm_postprocessing.ipynb
@@ -136,40 +136,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c45e2556",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": [
-    "# Subset by region: step 3 (combine) is auto-skipped because --region-name is set.\n",
-    "# Use this for one-region debugging or a re-run of a few failed regions.\n",
-    "sos run ./mnm_postprocessing.ipynb export_top_loci \\\n",
-    "    --region_file ./TADB_enhanced_cis.coding.bed \\\n",
-    "    --file_path /path/to/fine_mapping \\\n",
-    "    --prefix <fm_rds_prefix> \\\n",
-    "    --suffix <fm_rds_suffix> \\\n",
-    "    --name <study_name> \\\n",
-    "    --min_corr 0.8 \\\n",
-    "    --geno_ref ./Fungen_xQTL.ROSMAP_NIA_WGS.ROSMAP_NIA_WGS.MSBB_WGS_ADSP_hg38.MiGA.MAP_Brain-xQTL_Gwas_geno_0.STARNET.aligned.bim.gz \\\n",
-    "    --qtl_type cis \\\n",
-    "    --cwd ~/tmp/export_run \\\n",
-    "    --region-name ENSG00000048740 \\\n",
-    "    --mem 14G --walltime 72h \\\n",
-    "    -q slurm -j 100 -s build\n",
-    "\n",
-    "# Combine-step overrides:\n",
-    "#   --combine yes   force run step 3 on a subset (rare; e.g. re-combining after partial re-run)\n",
-    "#   --combine no    skip step 3 on a full run   (rare; e.g. combine offline)\n",
-    "#   default 'auto': run if no region filter, skip if --region-name / --region-list is set\n",
-    "#\n",
-    "# Note: --job_size defaults to 1 (one substep per sbatch). Pass --job_size N to bundle\n",
-    "# N substeps in parallel inside one task; requires N x cores and N x mem on the node.\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "29c7f8f4",
    "metadata": {
@@ -228,18 +194,6 @@
     "## Pipeline configuration and the `susie_to_tsv` workflow\n",
     "\n",
     "The cells below are the global parameters and the `susie_to_tsv` workflow definition, preserved from the original notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "57246889",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": [
-    "head /mnt/vast/hpc/csg/rf2872/Work/Multivariate/susie_2024_new/eQTL_meta.tsv"
    ]
   },
   {

--- a/code/SoS/molecular_phenotypes/QC/apa_impute.ipynb
+++ b/code/SoS/molecular_phenotypes/QC/apa_impute.ipynb
@@ -302,15 +302,6 @@
     "    tabix -p bed ${_output[0]} -f\n",
     "    gzip -dfk ${_output[0]}"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/code/SoS/multivariate_genome/MASH/mash_posterior.ipynb
+++ b/code/SoS/multivariate_genome/MASH/mash_posterior.ipynb
@@ -74,17 +74,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "cd /mnt/vast/hpc/csg/rf2872/Work/Multivariate/MASH/MWE"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -107,25 +96,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "#slice\n",
-    "sos run pipeline/mash_posterior.ipynb posterior  \\\n",
-    "    --analysis-units <(cat  MWE.list| cut -f 2) \\\n",
-    "    --cwd MWE_udr  \\\n",
-    "    --output_prefix  MWE_udr \\\n",
-    "    --vhat mle \\\n",
-    "    --mash_model MWE_udr/MWE_udr.EZ.V_mle.mash_model.rds \\\n",
-    "    --slice_method True \\\n",
-    "    --container containers/stephenslab.sif "
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -143,22 +113,6 @@
     "sos run pipeline/mash_posterior.ipynb posterior_cntrast_plot \\\n",
     "    --cwd output/mash_posterior \\\n",
     "    --analysis-units input/finemapping/protocol_example.analysis_units.txt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# no group\n",
-    "sos run pipeline/mash_posterior.ipynb mash_posterior_contrast   \\\n",
-    "    --posterior_file MWE_udr/mash_output_list_all \\\n",
-    "    --sum_file MWE.list  \\\n",
-    "    --cwd test \\\n",
-    "    --cells \"Ast\",\"Exc\",\"Inh\",\"Mic\",\"OPC\",\"Oli\",\"DLPFC_pQTL\",\"MiGA_GFM\",\"MiGA_GTS\",\"MiGA_SVZ\",\"MiGA_THA\" "
    ]
   },
   {
@@ -184,24 +138,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# 2 group\n",
-    "sos run pipeline/mash_posterior.ipynb mash_posterior_contrast   \\\n",
-    "    --posterior_file MWE_udr/mash_output_list_all \\\n",
-    "    --sum_file MWE.list  \\\n",
-    "    --cwd test_2group \\\n",
-    "    --cells \"Ast\",\"Exc\",\"Inh\",\"Mic\",\"OPC\",\"Oli\",\"DLPFC_pQTL\",\"MiGA_GFM\",\"MiGA_GTS\",\"MiGA_SVZ\",\"MiGA_THA\" \\\n",
-    "    --group1 \"Mic\",\"MiGA_GFM\",\"MiGA_GTS\",\"MiGA_SVZ\",\"MiGA_THA\" \\\n",
-    "    --group2 \"Ast\",\"Exc\""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -221,23 +157,6 @@
     "    --analysis-units input/finemapping/protocol_example.analysis_units.txt \\\n",
     "    --posterior-file input/protocol_example.posterior.rds \\\n",
     "    --sum-file input/protocol_example.sumstats.rds"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# recipe with 2 group\n",
-    "sos run pipeline/mash_posterior.ipynb mash_posterior_contrast   \\\n",
-    "    --posterior_file MWE_udr/mash_output_list_all \\\n",
-    "    --sum_file MWE.list  \\\n",
-    "    --cwd test_2group_recipe \\\n",
-    "    --cells \"Ast\",\"Exc\",\"Inh\",\"Mic\",\"OPC\",\"Oli\",\"DLPFC_pQTL\",\"MiGA_GFM\",\"MiGA_GTS\",\"MiGA_SVZ\",\"MiGA_THA\" \\\n",
-    "    --grouping_recipe recipe"
    ]
   },
   {

--- a/code/SoS/multivariate_genome/MASH/mash_preprocessing.ipynb
+++ b/code/SoS/multivariate_genome/MASH/mash_preprocessing.ipynb
@@ -282,23 +282,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "# generate random and null only\n",
-    "# sos run pipeline/mash_preprocessing.ipynb processing \\\n",
-    "#     --name protocol_example_protein \\\n",
-    "#     --sum_files test_pQTL_asso_list \\\n",
-    "#                test_pQTL_asso_list \\\n",
-    "#     --region_file test.region \\\n",
-    "#     --traits A B \n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "Bash"
@@ -316,11 +299,16 @@
    },
    "outputs": [],
    "source": [
-    "# generate strong only\n",
-    "# sos run pipeline/mash_preprocessing.ipynb susie_signal \\\n",
-    "#     --name protocol_example_protein \\\n",
-    "#     --susie_list protocol_example_protein.susie_output.txt \\\n",
-    "#     --traits A B \n"
+    "# Step B uses TensorQTL summary statistics to extract random/null effects.\n",
+    "# This step requires multi-trait sumstats; toy data has 1 trait so we\n",
+    "# document the interface only. Use the pre-generated mash_input.rds instead.\n",
+    "sos run pipeline/mash_preprocessing.ipynb random_null_tensorqtl \\\n",
+    "    --name protocol_example_mash \\\n",
+    "    --region_file input/finemapping/protocol_example.region \\\n",
+    "    --sum_files input/protocol_example.sumstats_list.txt \\\n",
+    "    --traits bulk_rnaseq \\\n",
+    "    --independent_variant_list input/ld/protocol_example.ld_pruned_variants.txt.gz \\\n",
+    "    --cwd output/mash_preprocessing\n"
    ]
   },
   {
@@ -341,23 +329,6 @@
    "outputs": [],
    "source": [
     "sos run pipeline/mash_preprocessing.ipynb -h"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "# generate mashr input directly\n",
-    "sos run pipeline/mash_preprocessing.ipynb susie_to_mash \\\n",
-    "        --name mash_example \\\n",
-    "        --coverage \"cs_coverage_0.7\" \\\n",
-    "        --per_chunk 100 \\\n",
-    "        --independent_variant_list ld_pruned_variants.txt.gz \\\n",
-    "        --susie_list susie_list.tsv \n"
    ]
   },
   {

--- a/code/SoS/pecotmr_integration/twas_ctwas.ipynb
+++ b/code/SoS/pecotmr_integration/twas_ctwas.ipynb
@@ -124,26 +124,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": [
-    "# Step1: region data assembly\n",
-    "sos run pipeline/twas_ctwas.ipynb ctwas \\\n",
-    "   --cwd ./output --name test --name_suffix TEST2 \\\n",
-    "   --thin 1 --prior_var_structure shared_all \\\n",
-    "   --gwas_meta_data data/twas/gwas_meta_test.tsv \\\n",
-    "   --ld_meta_data data/ld_meta_file_with_bim.tsv \\\n",
-    "   --xqtl_meta_data data/twas/mwe_twas_pipeline_test_small.tsv \\\n",
-    "   --twas_weight_cutoff 0 \\\n",
-    "   --regions data/twas/EUR_LD_blocks.bed \\\n",
-    "   --chrom 11 --gwas_study Bellenguez_2022 "
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
@@ -170,26 +150,6 @@
     "    --xqtl_meta_data input/twas/protocol_example.twas.xqtl_meta.tsv \\\n",
     "    --ld_meta_data input/ld_reference/protocol_example.ld_meta_file.tsv \\\n",
     "    --regions input/twas/protocol_example.twas.LD_blocks.chr22.bed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": [
-    "# Step2: estimate global parameters for either specific context group (single group: `--no-multi_group`) or shared group (multi-group: `--multi_group`)\n",
-    "sos run pipeline/twas_ctwas.ipynb ctwas \\\n",
-    "   --run_param_est --skip_assembly --thin 1 \\\n",
-    "   --prior_var_structure shared_all \\\n",
-    "   --cwd ./output --name test --name_suffix TEST2 \\\n",
-    "   --gwas_meta_data data/twas/gwas_meta_test.tsv \\\n",
-    "   --ld_meta_data data/ld_meta_file_with_bim.tsv \\\n",
-    "   --regions data/twas/EUR_LD_blocks.bed \\\n",
-    "   --xqtl_meta_data data/twas/mwe_twas_pipeline_test_small.tsv \\\n",
-    "   --gwas_study Bellenguez_2022"
    ]
   },
   {
@@ -220,28 +180,6 @@
     "    --ld_meta_data input/ld_reference/protocol_example.ld_meta_file.tsv \\\n",
     "    --regions input/twas/protocol_example.twas.LD_blocks.chr22.bed \\\n",
     "    --region-name chr22_10000000_19000000"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": [
-    "# Step3: cTWAS causal fine-mapping for a specific region \n",
-    "sos run pipeline/twas_ctwas.ipynb ctwas \\\n",
-    "    --run_finemapping --skip_assembly \\\n",
-    "    --prior_var_structure shared_all \\\n",
-    "    --cwd ./output \\\n",
-    "    --name test --name_suffix TEST \\\n",
-    "    --gwas_meta_data data/twas/gwas_meta_test.tsv \\\n",
-    "    --ld_meta_data data/ld_meta_file_with_bim.tsv \\\n",
-    "    --regions data/twas/EUR_LD_blocks.bed \\\n",
-    "    --xqtl_meta_data data/twas/mwe_twas_pipeline_test_small.tsv \\\n",
-    "    --gwas_study Bellenguez_2022 \\\n",
-    "    --region-name chr15_63051119_66680537"
    ]
   },
   {

--- a/code/SoS/reference_data/ld_reference_generation.ipynb
+++ b/code/SoS/reference_data/ld_reference_generation.ipynb
@@ -422,16 +422,6 @@
     "    write.table(ld_chrom_meta_file,paste0(ADSP_LD_chrom_file_path,\"/ld_meta_file_chr\",i,\".tsv\",sep=\"\"),sep=\"\\t\",col.names=TRUE,row.names = FALSE,quote=FALSE)\n",
     "}"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "71013096",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/code/SoS/reference_data/rss_ld_sketch.ipynb
+++ b/code/SoS/reference_data/rss_ld_sketch.ipynb
@@ -144,28 +144,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6fba40a9",
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "# Process one chromosome\n",
-    "sos run pipeline/rss_ld_sketch.ipynb process_block \\\n",
-    "    --vcf-base /path/to/vcfs/ \\\n",
-    "    --vcf-prefix your.prefix. \\\n",
-    "    --ld-block-file /path/to/EUR_LD_blocks.bed \\\n",
-    "    --cohort-id ADSP.R4.EUR \\\n",
-    "    --chrom 22 \\\n",
-    "    --output-dir output/rss_ld_sketch \\\n",
-    "    --W-matrix output/rss_ld_sketch/W_B10000.npy \\\n",
-    "    --mem 4G \\\n",
-    "    -J 16\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "452c348f-487f-44e4-96c1-75fe118cbc9a",
    "metadata": {},
@@ -187,28 +165,6 @@
     "    --cohort-id protocol_example. \\\n",
     "    --chrom 22 \\\n",
     "    --cwd output/rss_ld_sketch"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "03771811",
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "# Process all 22 chromosomes\n",
-    "sos run pipeline/rss_ld_sketch.ipynb process_block \\\n",
-    "    --vcf-base /restricted/projectnb/xqtl/R4_QC_NHWonly_rm_monomorphic \\\n",
-    "    --vcf-prefix gcad.qc.r4.wgs.36361.GATK.2022.08.15.biallelic.genotypes. \\\n",
-    "    --ld-block-file /restricted/projectnb/casa/oaolayin/ROSMAP_NIA_geno/EUR_LD_blocks.bed \\\n",
-    "    --cohort-id ADSP.R4.EUR \\\n",
-    "    --chrom 0 \\\n",
-    "    --output-dir output/rss_ld_sketch \\\n",
-    "    --W-matrix output/rss_ld_sketch/W_B10000.npy \\\n",
-    "    --mem 4G \\\n",
-    "    -J 126\n"
    ]
   },
   {


### PR DESCRIPTION
Extracts remaining safe narrative/tutorial/example cells from jaempawi/sync-sos-notebooks without importing implementation changes. Scope: 12 notebooks; no non-notebook files. Verification: SoS [step]/[global] source delta is 0 for all changed notebooks; changed cells are limited to tutorial/example/preview/empty cells; sldsc_enrichment now matches sync exactly; git diff check passes. Excluded non-narrative code such as mnm_postprocessing Adapter, EMS analysis/export cells, and ld_reference_generation VCF construction.