### PR TITLE
Refine narrative for 7 SoS notebooks (markdown-only)

### DIFF
--- a/code/SoS/association_scan/TensorQTL/TensorQTL.ipynb
+++ b/code/SoS/association_scan/TensorQTL/TensorQTL.ipynb
@@ -51,30 +51,6 @@
     "kernel": "SoS"
    },
    "source": [
-    "## Output Files\n",
-    "\n",
-    "**cis** (`output/tensorqtl_cis/`):\n",
-    "\n",
-    "| File | Description |\n",
-    "|---|---|\n",
-    "| `*.cis_qtl.pairs.tsv.gz` (+`.tbi`) | Nominal variant-phenotype association statistics |\n",
-    "| `*.cis_qtl_regional_significance.tsv.gz` | Region (gene) level significance |\n",
-    "| `*.cis_qtl_regional_significance.summary.txt` | Summary of regional results |\n",
-    "| `*.cis_qtl_pairs.<chr>.parquet` | Per-chromosome nominal results (parquet) |\n",
-    "\n",
-    "**trans** (`output/tensorqtl_trans/`):\n",
-    "\n",
-    "| File | Description |\n",
-    "|---|---|\n",
-    "| `*_geno_<chr>.trans_qtl.pairs.tsv.gz` (+`.tbi`) | Trans variant-phenotype association statistics |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
     "## Steps\n",
     "\n",
     "The commands below run on the included toy data and write results under `--cwd`. The genotype, phenotype, and covariate inputs are produced by the preprocessing notebooks."
@@ -114,6 +90,31 @@
    "source": [
     "### trans-QTL association\n",
     "\n",
+    "For trans-analysis:\n",
+    "\n",
+    " **Computational strategy designed for trans analysis:**\n",
+    " \n",
+    " Trans analysis faces significant memory challenges as we calculate all associations between all molecular traits × all genetic variants across the genome, creating a massive computational burden. To address this challenge, we implement a two-stage chromosome-based parallelization approach:\n",
+    "\n",
+    " **Stage 1 (trans_1): Chromosome-based parallelization**\n",
+    " - Phenotype data is processed per chromosome (e.g., 22 separate jobs for autosomes)\n",
+    " - For each phenotype chromosome, we test associations against variants from all 22 chromosomes\n",
+    " - This creates phenotype_chr × genotype_chr combinations (e.g., phenotype chr1 vs genotype chr1-22); Garbage was collected between each chromosome combination caculation to release memory\n",
+    " - Results are combined across all chromosome combinations and saved as compressed files\n",
+    "\n",
+    " **Stage 2 (trans_2): Significance filtering**\n",
+    " - Supports p-value cutoffs (`--pvalue-cutoff`) or q-value cutoffs (`--qvalue-cutoff`)\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
     "Test phenotypes against variants on a chosen genotype chromosome (`--trans-geno-chromosome 22`), restricted to the genes in `--region-list`. Trans analysis is memory-heavy genome-wide; here it is scoped to the toy chromosome."
    ]
   },
@@ -164,17 +165,6 @@
     "## Pipeline Code\n",
     "\n",
     "The SoS workflow definitions below are unchanged from the original protocol."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "## Anticipated Results\n",
-    "\n",
-    "The pipeline produces output files in the `output/` subdirectory named after the workflow step. Verify success by checking that output files exist and are non-empty. See the **Output** section above for the expected file names and formats."
    ]
   },
   {
@@ -432,6 +422,41 @@
     "        --covariate-file \"${covariate_file}\" \\\n",
     "        --trans-geno-chromosome \"${trans_geno_chromosome}\" \\\n",
     "        --numThreads ${numThreads}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Output Files\n",
+    "\n",
+    "**cis** (`output/tensorqtl_cis/`):\n",
+    "\n",
+    "| File | Description |\n",
+    "|---|---|\n",
+    "| `*.cis_qtl.pairs.tsv.gz` (+`.tbi`) | Nominal variant-phenotype association statistics |\n",
+    "| `*.cis_qtl_regional_significance.tsv.gz` | Region (gene) level significance |\n",
+    "| `*.cis_qtl_regional_significance.summary.txt` | Summary of regional results |\n",
+    "| `*.cis_qtl_pairs.<chr>.parquet` | Per-chromosome nominal results (parquet) |\n",
+    "\n",
+    "**trans** (`output/tensorqtl_trans/`):\n",
+    "\n",
+    "| File | Description |\n",
+    "|---|---|\n",
+    "| `*_geno_<chr>.trans_qtl.pairs.tsv.gz` (+`.tbi`) | Trans variant-phenotype association statistics |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Anticipated Results\n",
+    "\n",
+    "The pipeline produces output files in the `output/` subdirectory named after the workflow step. Verify success by checking that output files exist and are non-empty. See the **Output** section above for the expected file names and formats."
    ]
   }
  ],

--- a/code/SoS/misc/advanced_analysis/1_twas_mr_colocboost.ipynb
+++ b/code/SoS/misc/advanced_analysis/1_twas_mr_colocboost.ipynb
@@ -21,11 +21,11 @@
     "\n",
     "This is the final, **advanced-analysis** notebook in the `protocol_example` toy bundle. It consumes artifacts produced by earlier notebooks, so run them first in this order:\n",
     "\n",
-    "1. `data_preprocessing/2_genotype_preprocessing` → produces `output/plink/` (QC'd genotypes).\n",
-    "2. `data_preprocessing/1_phenotype_preprocessing` → produces `output/phenotype/` (molecular phenotypes by chrom).\n",
-    "3. `data_preprocessing/4_covariates_preprocessing` → produces `output/covariate/` (covariates + PCs).\n",
-    "4. `qtl_association_finemapping/1_xqtl_association` → produces `output/phenotype/phenotype_by_chrom_for_cis/` region lists.\n",
-    "5. `qtl_association_finemapping/2_finemapping` → produces `output/finemapping/susie_twas/twas_weights/` (the precomputed TWAS prediction weights Part 1 needs).\n",
+    "1. `data_preprocessing/2_genotype_preprocessing` \u2192 produces `output/plink/` (QC'd genotypes).\n",
+    "2. `data_preprocessing/1_phenotype_preprocessing` \u2192 produces `output/phenotype/` (molecular phenotypes by chrom).\n",
+    "3. `data_preprocessing/4_covariates_preprocessing` \u2192 produces `output/covariate/` (covariates + PCs).\n",
+    "4. `qtl_association_finemapping/1_xqtl_association` \u2192 produces `output/phenotype/phenotype_by_chrom_for_cis/` region lists.\n",
+    "5. `qtl_association_finemapping/2_finemapping` \u2192 produces `output/finemapping/susie_twas/twas_weights/` (the precomputed TWAS prediction weights Part 1 needs).\n",
     "\n",
     "Within this notebook the parts also chain to each other: earlier parts write to `output/twas/`, `output/susie_coloc/`, and `output/colocboost/`, which later parts read back.\n",
     "\n",
@@ -40,10 +40,10 @@
    "source": [
     "## Overview\n",
     "\n",
-    "1. **TWAS / MR** — transcriptome-wide association and Mendelian randomization.\n",
-    "2. **xQTL–GWAS enrichment** — global enrichment parameters used as colocalization priors.\n",
-    "3. **Pairwise colocalization (SuSiE-coloc)** — gene-by-gene xQTL–GWAS colocalization.\n",
-    "4. **ColocBoost** — multi-trait colocalization (xQTL-only and joint xQTL–GWAS modes).\n",
+    "1. **TWAS / MR** \u2014 transcriptome-wide association and Mendelian randomization.\n",
+    "2. **xQTL\u2013GWAS enrichment** \u2014 global enrichment parameters used as colocalization priors.\n",
+    "3. **Pairwise colocalization (SuSiE-coloc)** \u2014 gene-by-gene xQTL\u2013GWAS colocalization.\n",
+    "4. **ColocBoost** \u2014 multi-trait colocalization (xQTL-only and joint xQTL\u2013GWAS modes).\n",
     "\n",
     "The input files needed for each part are listed at the start of that part."
    ]
@@ -53,25 +53,18 @@
    "metadata": {
     "kernel": "SoS"
    },
+   "source": "## 1. TWAS\n\n### 1.1 Transcriptome-Wide Association Study (TWAS)\n\n**TWAS** is a method used to identify genes associated with complex traits by leveraging predicted gene expression levels. It combines precomputed molecular phenotype prediction weights with GWAS summary statistics to perform gene-trait association tests. \n\n\n#### 1.2 Input File Formats\n\n- GWAS Metadata (`--gwas_meta_data`)    \nA TSV file specifying study ID, chromosome, path to summary statistics, and a column mapping file.  \n- LD Reference Metadata (`--ld_meta_data`)    \nA TSV file with chromosome, start and end positions, and paths to LD matrix files.  \n- xQTL Weight Metadata (`--xqtl_meta_data`)    \nMetadata file containing gene region coordinates and paths to weight files stored in RDS format.  \n- Genomic Region Definitions (`--regions`)    \nA BED file defining analysis regions.  \n- xQTL Type Table (`--xqtl_type_table`)    \nA mapping file defining the molecular phenotype types and their associated biological context.\n\n\n#### 1.3 Key Parameters\n\n- `--rsq_cutoff 0.01`: Cross-validation R\u00b2 threshold used to determine whether a gene is predictable  \n- `--rsq_pval_cutoff 0.05`: Cross-validation p-value threshold  \n\n\n#### 1.4 Analysis Workflow  \n\n1). **Weight Loading**: Load TWAS prediction weights from RDS files.     \n2). **Predictable Gene Identification**: Determine which genes are reliably predictable based on cross-validation performance.    \n3). **TWAS Testing**: Compute TWAS Z-scores by combining predicted expression with GWAS statistics.    \n4). **Mendelian Randomization (MR)**: Perform MR analysis on candidate genes.\n\n### Input Files\n\n| File | Produced by | Used as |\n|------|-------------|---------|\n| `input/twas/protocol_example.twas.gwas_meta.tsv` | toy data prep | GWAS summary-statistics metadata |\n| `input/twas/protocol_example.twas.xqtl_meta.tsv` | toy data prep | xQTL weight metadata (gene region + RDS weights) |\n| `input/twas/protocol_example.twas.LD_blocks.chr22.bed` | toy data prep | analysis region definitions |\n| `input/twas/protocol_example.twas.data_type_table.txt` | toy data prep | xQTL molecular phenotype type table |\n| `input/LD_sketch/meta.tsv` | RSS LD sketch step | LD reference metadata |\n| `output/finemapping/susie_twas/twas_weights/*.univariate_twas_weights.rds` | fine-mapping (2_finemapping) | TWAS prediction weights |\n\nKey parameters: `--rsq_cutoff 0.01` (cross-validation R\u00b2 threshold for predictable genes) and `--rsq_pval_cutoff` (cross-validation p-value threshold).\n\nThe TWAS step proceeds in four stages. First it **loads** the precomputed prediction weights from the RDS files. It then identifies **predictable genes** \u2014 those whose expression is reliably imputable based on cross-validation performance (controlled by `--rsq_cutoff` and `--rsq_pval_cutoff`). For those genes it computes **TWAS Z-scores** by combining the predicted expression with the GWAS summary statistics, and finally performs **Mendelian Randomization (MR)** on the candidate genes to assess potential causal effects of expression on the trait.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
    "source": [
-    "## 1. TWAS\n",
-    "\n",
-    "**TWAS** tests gene–trait associations by combining precomputed molecular phenotype prediction weights with GWAS summary statistics, followed by Mendelian Randomization (MR) on candidate genes.\n",
-    "\n",
-    "### Input Files\n",
-    "\n",
-    "| File | Produced by | Used as |\n",
-    "|------|-------------|---------|\n",
-    "| `input/twas/protocol_example.twas.gwas_meta.tsv` | toy data prep | GWAS summary-statistics metadata |\n",
-    "| `input/twas/protocol_example.twas.xqtl_meta.tsv` | toy data prep | xQTL weight metadata (gene region + RDS weights) |\n",
-    "| `input/twas/protocol_example.twas.LD_blocks.chr22.bed` | toy data prep | analysis region definitions |\n",
-    "| `input/twas/protocol_example.twas.data_type_table.txt` | toy data prep | xQTL molecular phenotype type table |\n",
-    "| `input/LD_sketch/meta.tsv` | RSS LD sketch step | LD reference metadata |\n",
-    "| `output/finemapping/susie_twas/twas_weights/*.univariate_twas_weights.rds` | fine-mapping (2_finemapping) | TWAS prediction weights |\n",
-    "\n",
-    "Key parameters: `--rsq_cutoff 0.01` (cross-validation R² threshold for predictable genes) and `--rsq_pval_cutoff` (cross-validation p-value threshold).\n",
-    "\n",
-    "The TWAS step proceeds in four stages. First it **loads** the precomputed prediction weights from the RDS files. It then identifies **predictable genes** — those whose expression is reliably imputable based on cross-validation performance (controlled by `--rsq_cutoff` and `--rsq_pval_cutoff`). For those genes it computes **TWAS Z-scores** by combining the predicted expression with the GWAS summary statistics, and finally performs **Mendelian Randomization (MR)** on the candidate genes to assess potential causal effects of expression on the trait."
+    "To perform TWAS, you need to generate TWAS weight first.   \n",
+    "see: \n",
+    "- exercise notebook: `data/exercise_notebook/qtl_association_finemapping/2_finemapping.ipynb`\n",
+    "- pipeline: `pipeline/mnm_regression.ipynb susie_twas`"
    ]
   },
   {
@@ -210,20 +203,7 @@
    "metadata": {
     "kernel": "SoS"
    },
-   "source": [
-    "## 2. xQTL–GWAS enrichment\n",
-    "\n",
-    "Estimates global enrichment parameters (a0, a1) between xQTL and GWAS signals and converts them into colocalization priors (p1, p2, p12) used by the colocalization steps that follow.\n",
-    "\n",
-    "### Input Files\n",
-    "\n",
-    "| File | Produced by | Used as |\n",
-    "|------|-------------|---------|\n",
-    "| `input/susie_enloc_data/protocol_example.enloc.gwas_meta.tsv` | SuSiE-enloc demo | GWAS fine-mapping metadata |\n",
-    "| `input/susie_enloc_data/protocol_example.enloc.xqtl_meta.tsv` | SuSiE-enloc demo | xQTL fine-mapping metadata |\n",
-    "| `input/susie_enloc_data/protocol_example.enloc.context_meta.tsv` | SuSiE-enloc demo | context / analysis-name map |\n",
-    "| `input/susie_enloc_data/*` | SuSiE-enloc demo | fine-mapping result objects |"
-   ]
+   "source": "## 2. xQTL\u2013GWAS enrichment\n\nThis command executes the\u00a0**`xqtl_gwas_enrichment`**\u00a0workflow, which analyzes enrichment relationships between xQTL and GWAS data\n\n#### **Purpose**\n\nThe purpose of this step is to calculate enrichment parameters (a0, a1) between xQTL and GWAS data and generate prior probabilities (p1, p2, p12) for subsequent colocalization analysi\n\n#### **Method**\n\nThe workflow uses the\u00a0**`xqtl_enrichment_wrapper`**\u00a0function to perform enrichment analysis\u00a0. The method:\n\n1. Identifies GWAS blocks with top loci using single variant regression methods\n2. Maps analysis regions to overlapping gene regions with corresponding QTL files containing top loci tables\n3. Finds contexts within xQTL metadata that include top loci results for each gene\n4. Executes enrichment analysis to generate parameters\u00a0SuSiE_enloc.ipynb:102-106\n\n#### **Input Data**\n\n**Metadata files:**\n\n- **`-gwas-meta-data`**: Metadata file for GWAS fine-mapping results\n- **`-xqtl-meta-data`**: Metadata file for xQTL fine-mapping results\n- **`-context_meta`**: Meta file showing analysis names and contained contexts\n\n**Data paths:**\n\n- **`-qtl-path`**\u00a0and\u00a0**`-gwas_path`**: Directory paths for original fine-mapping results\n\n#### **Parameter Interpretation**\n\n**Object access parameters:**\n\n- **`-xqtl_finemapping_obj`**: Table name in xQTL RDS files to get fine-mapping results\n- **`-xqtl_varname_obj`**: Table name to get variable names\n- **`-gwas_finemapping_obj`**\u00a0and\u00a0**`-gwas_varname_obj`**: Corresponding parameters for GWAS data\n- **`-xqtl_region_obj`**: Table name to get region information\n\n#### **Output**\n\nGenerates enrichment analysis result files:\u00a0**`*.enrichment.rds`**, containing global enrichment estimates that combine all input data for each context. The output file path format is:\u00a0**`{cwd}/{name}.{context}.enrichment.rds`**\u00a0\n\n#### **Relationship to Downstream Analysis**\n\nThis enrichment analysis is a prerequisite step for colocalization analysis. The generated enrichment parameters serve as prior probability inputs for the\u00a0**`susie_coloc`**\u00a0workflow. In colocalization analysis, the system automatically reads enrichment result files to set p1, p2, and p12 prior probabilities.\n\n#### **Notes**\n\nThis workflow is the first stage of the SuSiE-enloc framework, specifically handling enrichment analysis between fine-mapping results from different genomic regions. The workflow automatically handles region overlap identification and context matching, providing statistically sound prior probabilities for subsequent colocalization analysis.\n\n### Input Files\n\n| File | Produced by | Used as |\n|------|-------------|---------|\n| `input/susie_enloc_data/protocol_example.enloc.gwas_meta.tsv` | SuSiE-enloc demo | GWAS fine-mapping metadata |\n| `input/susie_enloc_data/protocol_example.enloc.xqtl_meta.tsv` | SuSiE-enloc demo | xQTL fine-mapping metadata |\n| `input/susie_enloc_data/protocol_example.enloc.context_meta.tsv` | SuSiE-enloc demo | context / analysis-name map |\n| `input/susie_enloc_data/*` | SuSiE-enloc demo | fine-mapping result objects |\n"
   },
   {
    "cell_type": "markdown",
@@ -231,7 +211,7 @@
     "kernel": "SoS"
    },
    "source": [
-    "### **Step 1.** Run xQTL–GWAS enrichment analysis\n"
+    "### **Step 1.** Run xQTL\u2013GWAS enrichment analysis\n"
    ]
   },
   {
@@ -297,21 +277,7 @@
    "metadata": {
     "kernel": "SoS"
    },
-   "source": [
-    "## 3. Pairwise colocalization (SuSiE-coloc)\n",
-    "\n",
-    "Runs gene-by-gene xQTL–GWAS colocalization with `susie_coloc`, using either the enrichment-derived priors from Part 2 or default priors (`--skip-enrich`). LD metadata enables variant-level credible sets.\n",
-    "\n",
-    "### Input Files\n",
-    "\n",
-    "| File | Produced by | Used as |\n",
-    "|------|-------------|---------|\n",
-    "| `input/susie_enloc_data/protocol_example.enloc.gwas_meta.tsv` | SuSiE-enloc demo | GWAS fine-mapping metadata |\n",
-    "| `input/susie_enloc_data/protocol_example.enloc.xqtl_meta.tsv` | SuSiE-enloc demo | xQTL fine-mapping metadata (with overlap info) |\n",
-    "| `input/susie_enloc_data/protocol_example.enloc.context_meta.tsv` | SuSiE-enloc demo | context / analysis-name map |\n",
-    "| `input/ld_reference/protocol_example.ld_meta_file.tsv` | toy data prep | LD reference metadata for credible sets |\n",
-    "| `input/susie_enloc_data/*` | SuSiE-enloc demo | fine-mapping result objects |"
-   ]
+   "source": "## 3. Pairwise colocalization (SuSiE-coloc)\n\nThis command executes the\u00a0**`susie_coloc`**\u00a0workflow, which performs colocalization analysis between xQTL and GWAS data to identify shared causal variants.\n\n#### **Purpose**\n\nThe purpose of this step is to perform pairwise colocalization analysis between xQTL and GWAS fine-mapping results to determine whether observed associations share causal variants in overlapping genomic regions. This analysis identifies contexts with top loci results for each gene and applies\u00a0**`susie_coloc`**\u00a0to analyze each gene under each identified condition.\n\n#### **Method**\n\nThe workflow uses the\u00a0**`coloc_wrapper`**\u00a0function to perform colocalization analysis. The method:\n\n1. **Region Overlap Detection**: Identifies GWAS blocks that contain overlapping top loci variants for each gene using genomic coordinate matching\n2. **Prior Probability Setting**: Either loads enrichment-derived priors from previous analysis or uses default values when\u00a0**`-skip-enrich`**\u00a0is specified\n3. **Colocalization Analysis**: Applies\u00a0**`coloc_wrapper`**\u00a0for each xQTL-GWAS file pair with appropriate prior probabilities\n\n#### **Input Data**\n\n**Metadata files:**\n\n- **`-gwas-meta-data`**: GWAS fine-mapping results metadata\n- **`-xqtl-meta-data`**: xQTL fine-mapping results metadata with overlap information\n- **`-context_meta`**: Analysis names and context mappings\n\n**Data paths:**\n\n- **`-qtl-path`**\u00a0and\u00a0**`-gwas_path`**: Directory paths for original fine-mapping results\n\n#### **Parameter Interpretation**\n\n**Object access parameters:**\n\n- **`-xqtl_finemapping_obj`**: Table name in xQTL RDS files for fine-mapping results\n- **`-xqtl_varname_obj`**: Table name for variable names\n- **`-gwas_finemapping_obj`**\u00a0and\u00a0**`-gwas_varname_obj`**: Corresponding GWAS parameters\n- **`-xqtl_region_obj`**: Table name for region information\n\n**Analysis control parameters:**\n\n- **`-skip-enrich`**: Skips enrichment analysis and uses default prior probabilities (p1=1e-4, p2=1e-4, p12=5e-6)\n- **`-ld_meta_file_path`**: LD reference metadata for post-processing credible sets\n\n#### **Output**\n\nGenerates colocalization result files:\u00a0**`*.coloc.rds`**\u00a0containing colocalization statistics and posterior probabilities for each gene-context pair. When LD metadata is provided, also outputs credible set files (**`*.coloc_res`**) with variant-level results\u00a0SuSiE_enloc.ipynb:851\u00a0.\n\n#### **Notes**\n\nThis workflow represents the second stage of the SuSiE-enloc framework, performing gene-by-gene colocalization analysis on regions identified to have overlapping variants. The\u00a0**`--skip-enrich`**\u00a0parameter allows bypassing enrichment analysis when using default priors, making the analysis faster but potentially less statistically informed. The inclusion of LD metadata enables variant-level credible set reporting for significant colocalization results.\n\n### Input Files\n\n| File | Produced by | Used as |\n|------|-------------|---------|\n| `input/susie_enloc_data/protocol_example.enloc.gwas_meta.tsv` | SuSiE-enloc demo | GWAS fine-mapping metadata |\n| `input/susie_enloc_data/protocol_example.enloc.xqtl_meta.tsv` | SuSiE-enloc demo | xQTL fine-mapping metadata (with overlap info) |\n| `input/susie_enloc_data/protocol_example.enloc.context_meta.tsv` | SuSiE-enloc demo | context / analysis-name map |\n| `input/ld_reference/protocol_example.ld_meta_file.tsv` | toy data prep | LD reference metadata for credible sets |\n| `input/susie_enloc_data/*` | SuSiE-enloc demo | fine-mapping result objects |\n"
   },
   {
    "cell_type": "markdown",
@@ -382,9 +348,9 @@
     "| `output/susie_coloc/susie_coloc/*@<gene>.coloc.rds` | Per gene-context colocalization stats and posterior probabilities |\n",
     "| `output/susie_coloc/*.coloc_res` | Variant-level credible-set results (when LD metadata is supplied) |\n",
     "\n",
-    "Each `.coloc.rds` is a nested R list with `summary` (posterior probabilities for the five coloc hypotheses), `results` (SNP-level PP.H4), `priors`, and `analysis_region`. **PP.H4** is the probability that both traits share a single causal variant — higher values mean stronger colocalization evidence.\n",
+    "Each `.coloc.rds` is a nested R list with `summary` (posterior probabilities for the five coloc hypotheses), `results` (SNP-level PP.H4), `priors`, and `analysis_region`. **PP.H4** is the probability that both traits share a single causal variant \u2014 higher values mean stronger colocalization evidence.\n",
     "\n",
-    "Each `.coloc.rds` reports posterior probabilities for five mutually exclusive colocalization hypotheses for a given gene-trait pair: **PP.H0** (neither trait has an association in the region), **PP.H1** (only the xQTL is associated), **PP.H2** (only the GWAS trait is associated), **PP.H3** (both are associated but driven by *different* causal variants), and **PP.H4** (both are associated and share a *single* causal variant). A high **PP.H4** is the evidence for colocalization — it indicates the molecular and complex traits are likely driven by the same underlying variant."
+    "Each `.coloc.rds` reports posterior probabilities for five mutually exclusive colocalization hypotheses for a given gene-trait pair: **PP.H0** (neither trait has an association in the region), **PP.H1** (only the xQTL is associated), **PP.H2** (only the GWAS trait is associated), **PP.H3** (both are associated but driven by *different* causal variants), and **PP.H4** (both are associated and share a *single* causal variant). A high **PP.H4** is the evidence for colocalization \u2014 it indicates the molecular and complex traits are likely driven by the same underlying variant."
    ]
   },
   {
@@ -393,21 +359,116 @@
     "kernel": "SoS"
    },
    "source": [
-    "## 4. ColocBoost\n",
+    "#### Interpretation of `coloc` Analysis Results (Gene: `ENSG00000142798`)\n",
     "\n",
-    "Multi-trait colocalization that jointly analyzes molecular traits, optionally together with GWAS. Two modes are shown: **xQTL-only** (`--no-separate-gwas`) and **joint xQTL–GWAS** (`--separate-gwas`).\n",
+    "##### 1). Overall Structure\n",
     "\n",
-    "### Input Files\n",
+    "The provided object is a nested list in R, structured specifically for interpreting coloc analysis results. It contains five main components:\n",
     "\n",
-    "| File | Produced by | Used as |\n",
-    "|------|-------------|---------|\n",
-    "| `output/plink/protocol_example.genotype.merged.plink_qc.bed` | genotype preprocessing | merged genotypes |\n",
-    "| `output/phenotype/.../bulk_rnaseq.phenotype_by_chrom_files.region_list.txt` | phenotype preprocessing | phenotype region list |\n",
-    "| `output/covariate/protocol_example...Marchenko_PC.gz` | covariate preprocessing | covariates |\n",
-    "| `input/reference_data/TAD/TADB_enhanced_cis.bed` | reference data | cis association windows |\n",
-    "| `input/LD_sketch/meta.tsv` | RSS LD sketch step | LD reference metadata (joint mode) |\n",
-    "| `input/colocboost/gwas_meta.txt` | toy data prep | GWAS metadata, tab-separated (joint mode) |"
+    "- `summary`: Posterior probabilities for different coloc hypotheses.\n",
+    "- `results`: SNP-level posterior probabilities (PP.H4).\n",
+    "- `priors`: Priors used in Bayesian coloc analysis.\n",
+    "- `analysis_region`: Genomic region analyzed.\n",
+    "- `sets`: Credible sets; here `NULL`, indicating no credible set was formed.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "##### 2). `summary` Table\n",
+    "\n",
+    "This table contains posterior probabilities for five coloc hypotheses across SNP pairs:\n",
+    "\n",
+    "- `nsnps`: Number of SNPs analyzed (8826).\n",
+    "- `hit1`: Representative SNP for signal 1.\n",
+    "- `hit2`: Representative SNP for signal 2.\n",
+    "\n",
+    "Five coloc hypotheses probabilities:\n",
+    "\n",
+    "- `PP.H0.abf`: Neither trait has an association (null hypothesis).\n",
+    "- `PP.H1.abf`: Only trait 1 is associated.\n",
+    "- `PP.H2.abf`: Only trait 2 is associated.\n",
+    "- `PP.H3.abf`: Both traits are associated, but at different SNPs.\n",
+    "- `PP.H4.abf`: Both traits are associated at the same SNP (colocalization).\n",
+    "\n",
+    "Higher `PP.H4.abf` indicates stronger evidence for colocalization.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "##### 3). `results` Table\n",
+    "\n",
+    "Contains posterior probabilities for each of the 8826 SNPs across ten coloc scenarios (`rows`):\n",
+    "\n",
+    "- `snp`: SNP identifier (e.g., `\"1:20520243:G:A\"`).\n",
+    "- `SNP.PP.H4.row1` to `SNP.PP.H4.row10`: SNP-specific posterior probabilities for colocalization scenarios corresponding to each row in `summary`.\n",
+    "\n",
+    "High SNP-level posterior probabilities indicate likely colocalization positions.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "##### 4). `priors`\n",
+    "\n",
+    "Prior probabilities used in Bayesian analysis:\n",
+    "\n",
+    "- `p1`: Prior probability that trait 1 is associated.\n",
+    "- `p2`: Prior probability that trait 2 is associated.\n",
+    "- `p12`: Prior probability of colocalization between trait 1 and trait 2.\n",
+    "\n",
+    "Typically set low, reflecting conservative assumptions.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "##### 5). `analysis_region`\n",
+    "\n",
+    "Genomic region analyzed (e.g., `\"chr1:20520000-24080000\"`).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "##### 6). `sets`\n",
+    "\n",
+    "Contains credible sets (`cs`):\n",
+    "\n",
+    "- Here `cs` is `NULL`, indicating no credible set formed, possibly due to weak evidence.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "##### 7). Guidelines for Interpretation\n",
+    "\n",
+    "Interpretation of `PP.H4.abf`:\n",
+    "\n",
+    "- `PP.H4.abf > 0.75`: Strong evidence of colocalization.\n",
+    "- `0.25 \u2264 PP.H4.abf \u2264 0.75`: Moderate evidence of colocalization.\n",
+    "- `PP.H4.abf < 0.25`: Weak evidence of colocalization.\n",
+    "\n",
+    "When `PP.H4.abf` is high, further examine individual SNP-level probabilities (`results`) to pinpoint the SNP responsible for the shared signal.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "##### 8). Practical Example\n",
+    "\n",
+    "For row 2 of the `summary`:\n",
+    "\n",
+    "- `hit1`: `1:21912282:C:G`\n",
+    "- `hit2`: `1:22187644:C:A`\n",
+    "- `PP.H4.abf`: 0.02221 (~2.2%)\n",
+    "\n",
+    "The low `PP.H4.abf` indicates weak colocalization evidence. The higher `PP.H3.abf` (~40%) implies distinct SNP associations.\n",
+    "\n",
+    "Inspect `results` for high individual SNP posterior probabilities (e.g., > 0.9) to identify candidate colocalized SNPs.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "##### 9). Summary of Key Points\n",
+    "\n",
+    "- Inspect `summary` for overall colocalization evidence (`PP.H4.abf`).\n",
+    "- Check `results` for SNP-level posterior probabilities to identify potential colocalized SNPs.\n",
+    "- A `NULL` credible set indicates insufficient evidence to confidently define a credible SNP set."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": "## 4. ColocBoost\n\n**ColocBoost** is a multi-trait colocalization analysis tool designed to identify shared genetic variants influencing multiple molecular traits.\n\n\n### Core Features\n\n- Performs colocalization analysis within genomic regions accounting for **multiple causal variants**\n- Scales to the analysis of **hundreds of traits**\n- Supports inclusion or exclusion of **GWAS summary statistics**\n- Requires **individual-level xQTL data from the same cohort**\n\n### Analysis Modes\n\nColocBoost supports three major analysis modes:\n\n- xQTL-only Analysis (`--xqtl-coloc`):  \n  Performs colocalization only among molecular traits.\n\n- Joint GWAS Analysis (`--joint-gwas`):  \n  Integrates all GWAS traits in a combined colocalization analysis.\n\n- Separate GWAS Analysis (`--separate-gwas`):  \n  Performs colocalization analysis separately for each GWAS trait.\n\n### `--separate-gwas` vs `--no-separate-gwas`\n\n#### `--separate-gwas` (Enabled by default)\n\nWhen this flag is active, ColocBoost performs **individual colocalization analyses** for each GWAS trait.\n\n- Generates **one output file per GWAS study**\n- Output format: `{base_filename}.cb_xqtl_{study_name}.rds`\n- Supports **trait-specific** analysis and result inspection\n\n#### `--no-separate-gwas`\n\nWhen this flag is used, separate GWAS analyses are **not performed**.\n\n- Skips individual trait analysis\n- Reduces computational burden and the number of output files\n- Typically used **in combination with** `--joint-gwas`\n\n\n### Practical Examples\n\n#### xQTL-only Analysis\n\n- Use `--no-separate-gwas` to focus solely on **colocalization between molecular traits**\n\n#### GWAS-xQTL Joint Analysis\n\n- Use `--separate-gwas` to perform **trait-specific** colocalization for each GWAS dataset\n\n### Input Files\n\n| File | Produced by | Used as |\n|------|-------------|---------|\n| `output/plink/protocol_example.genotype.merged.plink_qc.bed` | genotype preprocessing | merged genotypes |\n| `output/phenotype/.../bulk_rnaseq.phenotype_by_chrom_files.region_list.txt` | phenotype preprocessing | phenotype region list |\n| `output/covariate/protocol_example...Marchenko_PC.gz` | covariate preprocessing | covariates |\n| `input/reference_data/TAD/TADB_enhanced_cis.bed` | reference data | cis association windows |\n| `input/LD_sketch/meta.tsv` | RSS LD sketch step | LD reference metadata (joint mode) |\n| `input/colocboost/gwas_meta.txt` | toy data prep | GWAS metadata, tab-separated (joint mode) |\n"
   },
   {
    "cell_type": "markdown",
@@ -444,7 +505,7 @@
     "kernel": "SoS"
    },
    "source": [
-    "### **Step 2.** Joint xQTL–GWAS ColocBoost (`--separate-gwas`)\n"
+    "### **Step 2.** Joint xQTL\u2013GWAS ColocBoost (`--separate-gwas`)\n"
    ]
   },
   {
@@ -503,9 +564,78 @@
     "| File | Contents |\n",
     "|------|----------|\n",
     "| `output/colocboost/.../cb_xqtl_*.rds` | xQTL-only ColocBoost result per gene |\n",
-    "| `output/colocboost_gwas/.../cb_xqtl_synthetic_gwas_*.rds` | Joint xQTL–GWAS ColocBoost result per gene |\n",
+    "| `output/colocboost_gwas/.../cb_xqtl_synthetic_gwas_*.rds` | Joint xQTL\u2013GWAS ColocBoost result per gene |\n",
     "\n",
-    "Each `.rds` is a named list (class `colocboost`) keyed by gene. The most useful elements are `cos_summary` (colocalized signals, empty if none), `cos_details` (details per colocalized signal), `ucos_details` (uncolocalized signals — many of these suggest GWAS signals independent of molecular QTLs), and `data_info` / `model_info` (traits analyzed and model convergence)."
+    "Each `.rds` is a named list (class `colocboost`) keyed by gene. The most useful elements are `cos_summary` (colocalized signals, empty if none), `cos_details` (details per colocalized signal), `ucos_details` (uncolocalized signals \u2014 many of these suggest GWAS signals independent of molecular QTLs), and `data_info` / `model_info` (traits analyzed and model convergence)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "### Colocboost Output File Structure\n\nEach `.rds` holds the `colocboost` result for one gene: a named list of class `\"colocboost\"` whose top-level element corresponds to that gene (e.g. `ENSG00000049246`). In joint xQTL\u2013GWAS mode (`--separate-gwas`) one such file is written per GWAS trait, named `{base_filename}.cb_xqtl_{study_name}.rds`. The internal structure is organized into the components below.\n\n#### Top-Level Components\n\n| Field | Type | Description |\n| --- | --- | --- |\n| `cos_summary` | NULL or list | Summary of colocalized signals (empty if none) |\n| `vcp` | NULL or list | Variant colocalization probabilities |\n| `cos_details` | NULL or list | Details for colocalized signals |\n| `data_info` | list | Information on traits, SNPs, z-scores, and coefficients |\n| `model_info` | list | Model convergence and log-likelihood tracking |\n| `ucos_details` | list | Results for **uncolocalized signals** (unique to colocboost) |\n| `region_info` | list | Genomic coordinates and extended window used in analysis |\n| `computing_time` | list | Timing for loading, QC, and model fitting steps |\n\n---\n\n#### data_info\n\n| Field | Description |\n| --- | --- |\n| `n_outcomes` | Number of traits analyzed |\n| `n_variables` | Number of SNPs analyzed |\n| `outcome_info` | Data frame of each trait\u2019s name, sample size, is_sumstats, and is_focal |\n| `variables` | Character vector of SNP IDs in `chr:pos:ref:alt` format |\n| `coef`, `z` | Trait-wise regression coefficients and z-scores (lists with length = number of traits) |\n\n---\n\n#### model_info\n\nTracks model convergence and optimization metrics for each trait:\n\n| Field | Description |\n| --- | --- |\n| `model_coveraged` | Whether the joint model converged |\n| `outcome_model_coveraged` | Per-trait convergence status |\n| `n_updates` | Total number of updates |\n| `outcome_n_updates` | Number of updates per trait |\n| `profile_loglik` | Log-likelihood per iteration (joint) |\n| `outcome_profile_loglik` | Log-likelihood per trait |\n| `outcome_proximity_obj` | Proximity statistics per trait per iteration |\n| `outcome_coupled_best_update_obj` | Coupled update quality per trait |\n| `jk_star` | Jackknife matrix (optional) |\n\n---\n\n#### ucos_details\n\nDescribes **uncolocalized effect sets** when no coloc is detected:\n\n| Field | Description |\n| --- | --- |\n| `ucos_index` | Indices of SNPs in each uncolocalized set |\n| `ucos_variables` | SNP IDs in each set |\n| `ucos_outcomes` | Trait name associated with each set (e.g., `\"Wightman\"`) |\n| `ucos_weight` | Per-SNP weights in each set |\n| `ucos_top_variables` | Top SNP per set |\n| `ucos_purity` | Pairwise correlation (min, max, median) across sets |\n| `ucos_outcomes_delta` | Delta value (importance) per set |\n\n> Interpretation:\n> \n> - Large number of `ucos` suggests GWAS has signals independent of molecular QTLs.\n> - `ucos_delta` indicates signal strength; higher = more trait variance explained.\n\n---\n\n#### region_info\n\n| Field | Description |\n| --- | --- |\n| `region_coord` | Original gene start/end coordinates |\n| `grange` | Extended region used for coloc (typically \u00b11.5Mb) |\n| `region_name` | Gene or region ID (can repeat if multiple traits mapped) |\n\n#### computing_time\n---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "\n",
+    "#### Key Results Interpretation in this MWE\n",
+    "\n",
+    "#### Analysis Overview\n",
+    "\n",
+    "- **Gene**: ENSG00000049246 (chromosome 1)\n",
+    "- **Traits analyzed**:  \n",
+    "  - `trait_A_ENSG00000049246` (xQTL, n = 150)  \n",
+    "  - `Wightman` (GWAS, n = 363,646)\n",
+    "- **Variants**: 6,872 variants analyzed within the region\n",
+    "\n",
+    "#### Missing Core Results\n",
+    "\n",
+    "- `cos_summary`: `NULL` \u2013 No colocalized effects detected  \n",
+    "- `vcp`: `NULL` \u2013 No variant colocalization probabilities computed  \n",
+    "- `cos_details`: `NULL` \u2013 No detailed colocalization results available\n",
+    "\n",
+    "This indicates no significant colocalization between xQTL and GWAS signals for the target gene.\n",
+    "\n",
+    "These results suggest that while the Wightman GWAS shows multiple independent association signals in the region, these signals do not colocalize with the xQTL effects. \n",
+    "\n",
+    "### Uncolocalized Effects (`ucos_details`)\n",
+    "\n",
+    "The analysis detected 11 uncolocalized effects (`ucos1:y2` to `ucos11:y2`), all associated with the GWAS trait `Wightman`.  \n",
+    "\n",
+    "- **Top variants**:  \n",
+    "  - `chr1:9797684:A:C`  \n",
+    "  - `chr1:9809863:C:T`  \n",
+    "  - `chr1:9830837:C:T`  \n",
+    "- **Effect strengths**:  \n",
+    "  - Ranged from extremely weak (`ucos9:y2` with weights \u2248 9e-13)  \n",
+    "  - To moderate (`ucos5:y2` with weights \u2248 3e-06)  \n",
+    "- **Delta values**:  \n",
+    "  - Effect size contributions ranged from 0.0088 to 0.0743\n",
+    "\n",
+    "### Model Convergence\n",
+    "\n",
+    "- `trait_A_ENSG00000049246`: Converged after 20 updates (`model_coveraged = TRUE`)\n",
+    "- `Wightman`: Did not converge after 501 updates (`model_coveraged = FALSE`)\n",
+    "\n",
+    "\n",
+    "### Technical Details\n",
+    "\n",
+    "- **Analysis region**: chr1:6,120,000\u20139,960,000  \n",
+    "- **Gene coordinates**: chr1:7,784,319\u20137,845,176  \n",
+    "\n",
+    "**Computing time**:  \n",
+    "- Data loading: ~3 minutes  \n",
+    "- Quality control: ~17 seconds  \n",
+    "- Model fitting:  \n",
+    "  - xQTL: ~15 seconds  \n",
+    "  - GWAS integration: ~4.7 minutes"
    ]
   }
  ],

--- a/code/SoS/misc/data_preprocessing/3_genotype_pca.ipynb
+++ b/code/SoS/misc/data_preprocessing/3_genotype_pca.ipynb
@@ -212,6 +212,16 @@
     "kernel": "SoS"
    },
    "source": [
+    "The final pca output that we will use in cov processing\n",
+    "`related.plink_qc.extracted.pca.projected.rds`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
     "## Output Files\n",
     "\n",
     "| File | Description |\n",

--- a/code/SoS/misc/data_preprocessing/4_covariates_preprocessing.ipynb
+++ b/code/SoS/misc/data_preprocessing/4_covariates_preprocessing.ipynb
@@ -21,9 +21,9 @@
     "\n",
     "Covariates correct for confounders so that detected QTLs reflect true genotype-phenotype associations rather than technical or population artifacts. This notebook assembles three kinds of covariates into one file:\n",
     "\n",
-    "1. **Known covariates** \u2014 measured variables from the fixed covariate file (e.g. `msex`, `age_death`, `pmi`, `study`).\n",
-    "2. **Genotype PCs** \u2014 the top PCs from the genotype PCA (`3_genotype_pca.ipynb`), which capture population structure.\n",
-    "3. **Hidden factors** \u2014 unobserved sources of variation (batch effects, technical noise) inferred from the phenotype residuals.\n",
+    "1. **Known covariates** — measured variables from the fixed covariate file (e.g. `msex`, `age_death`, `pmi`, `study`).\n",
+    "2. **Genotype PCs** — the top PCs from the genotype PCA (`3_genotype_pca.ipynb`), which capture population structure.\n",
+    "3. **Hidden factors** — unobserved sources of variation (batch effects, technical noise) inferred from the phenotype residuals.\n",
     "\n",
     "The two steps are: (1) **merge** the genotype PCs with the known covariates, and (2) **compute residuals** on the merged covariates and run **hidden-factor analysis** (PCA on the residuals, with the number of factors chosen by the Marchenko-Pastur distribution). The result is a single covariate file ready for TensorQTL.\n"
    ]
@@ -50,18 +50,9 @@
     "kernel": "SoS"
    },
    "source": [
-    "## Steps\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "### **Step 1.** Merge genotype PCs with known covariates\n",
+    "### Step 1: Merge genotype PCs with known covariates\n",
     "\n",
-    "Merge the genotype PCA results with the known covariate file. `--k` sets how many genotype PCs to keep; here it is read from the scree table as the number of PCs that together explain < 80% of variance (15 for this dataset). `--tol-cov 0.4` is the maximum allowed missingness rate for covariates. The output is a merged covariate table (known covariates + genotype PCs).\n"
+    "Merge the genotype PCA results with the known covariate file. The aim of `merge_genotype_pc` is to combine the principal components from the genotype PCA module with the fixed covariate data for use in subsequent analyses. `--k` sets how many genotype PCs to keep; here it is read from the scree table as the number of PCs that together explain <80% of variance (15 for this dataset). `--tol-cov 0.4` is the maximum allowed missingness rate for covariates, and `--mean-impute-missing` fills any missing covariate values with their column mean. The output is a merged covariate table (known covariates + genotype PCs) saved as `.plink_qc.prune.pca.gz`."
    ]
   },
   {
@@ -86,9 +77,9 @@
     "kernel": "SoS"
    },
    "source": [
-    "### **Step 2.** Compute residuals and run hidden-factor analysis\n",
+    "### Step 2: Compute residuals and run hidden-factor analysis\n",
     "\n",
-    "Using the phenotype and the merged covariates from Step 1, this step first regresses out the known covariates to obtain phenotype **residuals** (`Marchenko_PC_1`), then runs PCA on those residuals and keeps the components that pass the **Marchenko-Pastur** significance threshold as **hidden factors** (`Marchenko_PC_2`). `--mean-impute-missing` fills any missing covariate values with their column mean. The final output combines the known covariates, genotype PCs, and hidden factors \u2014 this is the covariate file used in downstream QTL analysis.\n"
+    "Using the phenotype and the merged covariates from Step 1, this step first regresses out the known covariates to obtain phenotype residuals (`Marchenko_PC_1`), then runs PCA on those residuals and keeps the components that pass the Marchenko-Pastur significance threshold as hidden factors (`Marchenko_PC_2`). Hidden factor analysis identifies and quantifies unobserved sources of variability — such as batch effects, technical artifacts, or other unmeasured biological factors — that influence gene expression. By extracting these major sources of variability and choosing the number of PCs to retain via the Marchenko-Pastur distribution, the workflow corrects batch effects and reduces technical noise. The final output combines the known covariates, genotype PCs, and hidden factors into a single compressed covariate file used in downstream QTL analysis."
    ]
   },
   {
@@ -104,6 +95,17 @@
     "    --phenoFile output/rnaseq/protocol_example.rnaseq.bed.bed.gz \\\n",
     "    --covFile output/covariate/protocol_example.covariates.protocol_example.genotype.merged.plink_qc.protocol_example.genotype.king.unrelated.plink_qc.prune.pca.gz \\\n",
     "    --mean-impute-missing\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "### Final covariates list\n",
+    "\n",
+    "The final covariate file contains 53 covariates: the known covariates `msex`, `age_death`, and `pmi` from the raw covariate data, genotype PCs `PC1`-`PC15` from the genotype PCA, and hidden factors `Hidden_Factor_PC1`-`Hidden_Factor_PC10` from the Marchenko-Pastur analysis. The known covariates capture biological and technical sources of variation: `msex` (genetic sex), `age_death` (age at death, which influences age-related expression patterns), and `pmi` (post-mortem interval, which affects RNA quality and sample stability)."
    ]
   },
   {

--- a/code/SoS/pecotmr_integration/twas_ctwas.ipynb
+++ b/code/SoS/pecotmr_integration/twas_ctwas.ipynb
@@ -2,22 +2,23 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Prerequisites\n\nRequires TWAS weights (`protocol_example.twas_weights.rds`) from `mnm_regression` and GWAS summary statistics."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"
    },
    "source": [
-    "# TWAS and cTWAS\n",
+    "# TWAS, cTWAS and MR\n",
     "\n",
     "## Description\n",
     "\n",
-    "This notebook runs a transcriptome-wide association analysis (TWAS) followed by causal-TWAS (cTWAS) fine-mapping on the toy dataset. Starting from pre-computed SuSiE-TWAS prediction weights for one gene on chromosome 22, it tests each molecular context for association with a GWAS trait, keeps the imputable models selected by cross-validation, and then jointly fine-maps genes and SNPs within an LD block to identify which signals are likely to be directly causal rather than driven by correlation. The original protocol notebook also documents optional Mendelian Randomization and quantile-TWAS steps; those workflow definitions are preserved at the end of this notebook for reference."
+    "This module provides software implementations for transcriptome-wide association analysis (TWAS), Quantile TWAS, and variant selection that yields sparse signals for cTWAS (causal TWAS) analysis following the multi-group cTWAS method of Qian et al. (2024+). It additionally performs Mendelian Randomization using fine-mapping instrumental variables (IV) as described in Zhang et al. (2020) for \"causal\" effect estimation and model validation. The unit of analysis is a single gene-trait pair.\n",
+    "\n",
+    "This notebook runs TWAS followed by cTWAS fine-mapping on a toy chr22 dataset: starting from pre-computed SuSiE-TWAS prediction weights for one gene, it tests each molecular context for association with a GWAS trait, keeps the imputable models selected by cross-validation, and then jointly fine-maps genes and SNPs within an LD block to identify which signals are likely to be directly causal rather than driven by correlation. Quantile TWAS extends traditional TWAS by testing genetic effects at different quantiles of the trait distribution.\n",
+    "\n",
+    "This procedure is a continuation of the SuSiE-TWAS workflow: it assumes that xQTL fine-mapping has been performed and molecular-trait prediction weights pre-computed (to be used for TWAS). Cross-validation of TWAS weights is optional but highly recommended.\n",
+    "\n",
+    "**Prerequisites:** TWAS weights (`protocol_example.twas_weights.rds`) from `mnm_regression`, plus GWAS summary statistics and an LD matrix for the region of interest.\n",
+    "\n",
+    "**Timing** (toy chr22 dataset): `twas` ~50 sec; `ctwas` ~42 sec."
    ]
   },
   {
@@ -26,40 +27,34 @@
     "kernel": "SoS"
    },
    "source": [
-    "## Steps\n",
+    "## Step 1: TWAS\n",
     "\n",
-    "i. Run TWAS to obtain per-context gene-trait association statistics and select imputable models.\n",
+    "Extract the GWAS z-scores and the corresponding LD matrix for the region of interest, (optionally) run allele-matching QC, process the SuSiE-TWAS weights, run the association test for each molecular context across multiple sets of weights, and keep the best cross-validated model per gene. A gene-context pair is considered imputable when its cross-validated performance reaches adjusted $r^2$ >=0.01 and p-value <0.05 in at least one method; non-imputable genes are dropped.\n",
     "\n",
-    "ii. Assemble the cTWAS region input by combining TWAS gene z-scores, GWAS SNP z-scores, and LD reference information.\n",
+    "*Notes:* specifying a `column_file_path` (YAML) enables `load_rss_data()`, which standardizes column names and can generate missing `z`/`beta` columns via `col_to_flip`; without it, the simpler `tabix_region()` is used. Use `--comment_string \"#\"` to handle comment lines in the summary statistics file (by default no comment symbol is assumed). For LASSO, Elastic Net, and mr.ash the weights are taken as-is for QTL variants overlapping GWAS variants, while SuSiE weights can be adjusted to exactly match GWAS variants.\n",
     "\n",
-    "iii. Estimate the global prior parameters across the screened region.\n",
+    "**Input \u2014 GWAS data interface (similar to `susie_rss`):**\n",
+    "- GWAS summary statistics files: tab-delimited, tabix-indexed by `chrom`/`pos`; first 4 columns `chrom`, `pos`, `A1`, `A2`. For MR, `effect_allele_frequency` and sample-size columns are required.\n",
+    "- Optional column-mapping YAML: required `chrom`, `pos`, `A1`, `A2`, `z` (or `betahat`/`sebetahat`); optional `n`, `var_y`.\n",
+    "- Optional GWAS meta-file (`study_id`, chrom, file path, optional mapping file; chrom `0` = genome-wide):\n",
+    "```\n",
+    "study_id   chrom   file_path      column_mapping_file\n",
+    "study1     1       gwas1.tsv.gz   column_mapping.yml\n",
+    "study1     2       gwas2.tsv.gz   column_mapping.yml\n",
+    "```\n",
+    "- LD reference metadata: single TSV with `#chrom`, `start`, `end`, LD-matrix path (comma-separated matrix,bim), genome build. See the [LD reference preparation doc](https://statfungen.github.io/xqtl-protocol/code/reference_data/ld_reference_generation.html).\n",
+    "- xQTL weight database (RDS, region -> context -> weight matrix), metadata columns `#chr`, `start`, `end`, `TSS`, `region_id`, `original_data`:\n",
+    "```\n",
+    "#chr  start  end       region_id        TSS      original_data\n",
+    "chr1  0      6480000   ENSG00000008128  1724356  KNIGHT_pQTL.ENSG00000008128.univariate_susie_twas_weights.rds, ... (truncated)\n",
+    "```\n",
     "\n",
-    "iv. Run cTWAS fine-mapping on the region to obtain causal posterior inclusion probabilities (PIP) for genes and SNPs."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Timing** (toy chr22 dataset):\n- `twas`: ~50 sec\n- `ctwas`: ~42 sec\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "## Input Files\n",
-    "\n",
-    "| File | Description |\n",
-    "|------|-------------|\n",
-    "| `input/twas/protocol_example.twas.gwas_meta.tsv` | GWAS summary-statistics meta file (study id, chromosome, path to the tabix-indexed sumstats). |\n",
-    "| `input/twas/protocol_example.twas.gwas_sumstats.chr22.tsv.gz` | Tabix-indexed GWAS summary statistics for chr22 (with `.tbi`). |\n",
-    "| `input/twas/protocol_example.twas.xqtl_meta.tsv` | xQTL weight-database meta file pointing to the pre-computed SuSiE-TWAS weight RDS for the gene. |\n",
-    "| `input/twas/protocol_example.twas.data_type_table.txt` | Maps each context to its molecular data type (e.g. `bulk_rnaseq` -> `eQTL`). |\n",
-    "| `input/twas/protocol_example.twas.LD_blocks.chr22.bed` | LD block definitions used to scope the analysis region. |\n",
-    "| `input/ld_reference/protocol_example.ld_meta_file.tsv` | LD reference metadata pointing to the per-chromosome LD matrices. |"
+    "**Output \u2014 TWAS result table** (imputable genes only): `gwas_study, chrom, start, end, block, gene, TSS, context, is_imputable, method, is_selected_method, rsq_adj_cv, pval_cv, twas_z, twas_pval`. Key columns: `TSS` = transcription start site; `start`/`end` = gene window from the [extended TADB window](https://github.com/cumc/xqtl-analysis/blob/main/resource/TADB_enhanced_cis.coding.bed); `is_imputable` = CV r-square >0.01 and pvalue <0.05 in >=1 method; `is_selected_method` = best model (highest CV r-square, CV pvalue <0.05); `block` = LD region of the gene's TSS based on [predefined LD blocks](https://github.com/cumc/xqtl-data/blob/main/descriptor/reference_data/ld_reference.md).\n",
+    "```\n",
+    "chr  molecular_id      TSS        start      end        context          gwas_study           method  is_imputable  is_selected_method  rsq_cv  pval_cv   twas_z  twas_pval\n",
+    "1    ENSG00000060718   103108871  101000000  104000000  AC_DeJager_eQTL  Bellenguez_EADB_2022 bayes_r TRUE          TRUE                0.25    3.39e-39  0.39    0.69\n",
+    "10   ENSG00000048740   10798396   9320000    12336675   Ast_DeJager_eQTL Bellenguez_EADI_2022 enet    TRUE          FALSE               0.16    2.72e-17  -0.21   0.83\n",
+    "```\n"
    ]
   },
   {
@@ -68,9 +63,39 @@
     "kernel": "SoS"
    },
    "source": [
-    "### Step 1. Run TWAS\n",
+    "## Step 2: cTWAS \u2014 region assembly, global parameters, and fine-mapping\n",
     "\n",
-    "Extract the GWAS z-scores and LD matrix for the region, process the SuSiE-TWAS weights, run the association test for each context, and keep the best cross-validated (imputable) model per gene."
+    "Combine the selected best-performing TWAS prediction models, TWAS gene z-scores, GWAS SNP z-scores, and LD reference region information into the per-region cTWAS input; estimate the global group prior across all regions; then screen and fine-map regions to obtain posterior inclusion probabilities (PIP) for genes and SNPs. The section is split into three runs: region-data assembly, global-parameter estimation (`--run_param_est`), and causal fine-mapping (`--run_finemapping`).\n",
+    "\n",
+    "The cTWAS R package is required: `remotes::install_github(\"xinhe-lab/ctwas\", ref = \"multigroup\")`. Variant selection is performed based on the `top_loci` table, SuSiE CS set, or twas-weights effect size when any of `twas_weight_cutoff` (default=0), `cs_min_cor` (default=0), `min_pip_cutoff` (default=0), or `max_num_variants` (default=Inf) is set away from its default. The prior can use a single shared group via `--prior_var_structure shared_all` or the multi-group model via `--multi_group`.\n",
+    "\n",
+    "**Input \u2014 TWAS region information** (multiple TWAS and SNP data within each region are combined for joint inference to select variables \u2014 genes or SNPs \u2014 likely to be directly associated with the phenotype rather than via correlation):\n",
+    "```\n",
+    "chrom  start  end    block_id\n",
+    "1      1000   5000   block1\n",
+    "2      2000   6000   block2\n",
+    "3      3000   7000   block3\n",
+    "```\n",
+    "\n",
+    "**Output \u2014 cTWAS fine-mapping** (per variable: `id, molecular_id, type, context, susie_pip, group, cs, region_id, z`):\n",
+    "```\n",
+    "id                                     molecular_id     type  context           susie_pip          cs  region_id            z\n",
+    "ENSG00000148429|eQTL_Inh_DeJager_eQTL  ENSG00000148429  eQTL  Inh_DeJager_eQTL  0.07121779052573   L1  10_10500888_12817813 -6.20856901762341\n",
+    "10:10504379:T:C                        10:10504379:T:C  SNP   SNP               0.987261359280169      10_10500888_12817813 1.03614457831325\n",
+    "```\n",
+    "\n",
+    "For candidate genes, **MR** can subsequently be run: limit MR to genes with cTWAS significance AND a strong instrumental variable (fine-mapping PIP or CS); use fine-mapped xQTL with GWAS data; for multiple IVs aggregate via fixed-effect meta-analysis; and exclude results with severe exclusion-restriction (ER) violations.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Step 3: Quantile TWAS\n",
+    "\n",
+    "Use pre-computed TWAS weights for quantile-specific testing: for each quantile level, cluster and integrate by fixed and dynamic region groups, extract the relevant GWAS z-scores and LD matrix for the region, and perform quantile region-specific association tests, identifying variants whose effects vary across different quantile regions of the phenotype distribution. Use `--region-name` (formatted as `chr_start_stop`) to focus on specific blocks, or `--region` to analyze a selected list of regions.\n"
    ]
   },
   {
@@ -94,17 +119,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "### Step 2. cTWAS - assemble region data\n",
-    "\n",
-    "Combine the selected TWAS prediction models, TWAS gene z-scores, GWAS SNP z-scores, and LD reference information into the per-region cTWAS input."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -124,17 +138,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "### Step 3. cTWAS - estimate global parameters\n",
-    "\n",
-    "Estimate the global prior parameters used by the fine-mapping model (here using a single shared group via `--prior_var_structure shared_all`)."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -150,17 +153,6 @@
     "    --xqtl_meta_data input/twas/protocol_example.twas.xqtl_meta.tsv \\\n",
     "    --ld_meta_data input/ld_reference/protocol_example.ld_meta_file.tsv \\\n",
     "    --regions input/twas/protocol_example.twas.LD_blocks.chr22.bed"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "### Step 4. cTWAS - causal fine-mapping\n",
-    "\n",
-    "Run cTWAS fine-mapping on the region to obtain posterior inclusion probabilities (PIP) for genes and SNPs."
    ]
   },
   {
@@ -188,35 +180,9 @@
     "kernel": "SoS"
    },
    "source": [
-    "## Output Files\n",
-    "\n",
-    "| File | Description |\n",
-    "|------|-------------|\n",
-    "| `output/twas/<name>.<region>.twas.tsv.gz` | Per-region TWAS results table (gene, context, method, imputability, z-score, p-value). |\n",
-    "| `output/twas/<name>.<region>.twas_data.rds` | Harmonized cTWAS input data bundle for the region. |\n",
-    "| `output/ctwas/<name>.<region>.ctwas.tsv` | cTWAS fine-mapping result with causal PIPs for genes and SNPs. |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "## Anticipated Results\n",
-    "\n",
-    "The TWAS step yields a table of gene-context association statistics with imputable models flagged, and the cTWAS step returns posterior inclusion probabilities indicating which genes or variants in the region show evidence of being directly causal for the trait."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
     "## Workflow implementation\n",
     "\n",
-    "The cells below are the original pipeline step definitions (`[global]`, `[get_analysis_regions]`, `[twas]`, `[ctwas_1]`, `[ctwas_2]`, `[ctwas_3]`, `[quantile_twas]`), preserved verbatim from the protocol notebook."
+    "The following cells define the SoS workflow steps (`[global]`, `[get_analysis_regions]`, `[twas]`, `[ctwas_1]`, `[ctwas_2]`, `[ctwas_3]`, `[quantile_twas]`) invoked by the commands in the steps above."
    ]
   },
   {
@@ -703,7 +669,7 @@
     "            }\n",
     "        )\n",
     "    \n",
-    "        # res is NULL → skip safely\n",
+    "        # res is NULL \u2192 skip safely\n",
     "        if (is.null(res) || is.null(res$twas_result)) {\n",
     "            message(paste(\"Batch\", batch, \"returned no results\"))\n",
     "            twas_results_db[[batch]] <- NULL\n",

--- a/code/SoS/reference_data/generalized_TADB.ipynb
+++ b/code/SoS/reference_data/generalized_TADB.ipynb
@@ -2,31 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "92a800f4",
+   "id": "4b5c8877",
    "metadata": {
     "kernel": "SoS"
    },
    "source": [
-    "# Generation of Topologically Associated Domains and their Boundaries"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d5d59d43",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
+    "# Generation of Topologically Associated Domains and their Boundaries\n",
+    "\n",
     "## Description\n",
     "\n",
     "This notebook builds **TAD boundaries (TADBs)** and TADB-enhanced cis windows from tissue/brain TAD calls. It runs in two conceptual stages: (i) *manage TAD redundancy* by recursively merging overlapping specific TADs (those whose overlap exceeds a cutoff) into a smaller set of generalized TADs, and (ii) *generate TADB-enhanced cis windows and extended TADBs* by deriving boundaries from the generalized + specific TADs and joining them with gene coordinates to produce per-gene cis windows.\n",
     "\n",
-    "> **Synthetic-data note.** This minimal working example runs on a small synthetic set of chr22 TAD blocks (`protocol_example.brain_TADs.txt`) and a chr22 gene table (`protocol_example.gene_start_end.tsv`, derived from the protocol gene-model GTF). It is for demonstration only and does not reproduce a full genome-wide TADB build."
+    "During fine mapping we often use a cis window (up & downstream 1Mb of the start of a gene) as the fine-mapping region. That choice lacks a biological justification, so here we instead extend regions using TAD structure, producing both extended TADBs and TADB-enhanced cis windows since each serves a different goal. Genes within each TADB are extended by their 1Mb cis windows and the outermost boundary is taken, yielding roughly 1,381 TADBs that can serve as functional units for epigenetic analysis.\n",
+    "\n",
+    "> **Synthetic-data note.** This minimal working example runs on a small synthetic set of chr22 TAD blocks (`protocol_example.brain_TADs.txt`) and a chr22 gene table (`protocol_example.gene_start_end.tsv`, derived from the protocol gene-model GTF). It is for demonstration only and does not reproduce a full genome-wide TADB build.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6cc19581",
+   "id": "90ebc2fb",
    "metadata": {
     "kernel": "SoS"
    },
@@ -36,49 +30,159 @@
     "- `--tad-input`: tab-separated TAD coordinates with columns `chr`, `start`, `end` (no header). Example: `input/tadb/protocol_example.brain_TADs.txt`.\n",
     "- `--gene-coords`: gene coordinate table with columns `index`, `#chr`, `start`, `end`, `gene_id`, `gene_name` (derived from the gene-model GTF). Example: `input/tadb/protocol_example.gene_start_end.tsv`.\n",
     "- `--cwd`: output directory (default `output/tadb`).\n",
-    "- `--overlap-cutoff`: minimum percent overlap to merge two specific TADs into one generalized TAD (default `80`)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2d12ed03",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
+    "- `--overlap-cutoff`: minimum percent overlap to merge two specific TADs into one generalized TAD (default `80`).\n",
+    "\n",
+    "For a genome-wide build, the raw inputs are `Cortex_DLPFC_Schmitt2016-raw_TADs.txt` and `Hippocampus_Schmitt2016-raw_TADs.txt` (hg38 cortex/hippocampus TAD regions, [cf. McArthur et al 2021](https://doi.org/10.1016/j.ajhg.2021.01.001) and [Schmitt et al 2017](https://doi.org/10.1016/j.celrep.2016.10.061); available at [3dgenome.fsm.northwestern.edu](http://3dgenome.fsm.northwestern.edu/publications.html)) together with the gene model `Homo_sapiens.GRCh38.103.chr.reformatted.collapse_only.gene.ERCC.gtf`.\n",
+    "\n",
     "## Output\n",
     "\n",
-    "- `generalized_TAD.tsv`: redundancy-managed (merged) generalized TADs (`chr`, `start`, `end`).\n",
-    "- `generalized_TADB.tsv`: generalized TAD boundaries with a `TADB` index.\n",
-    "- `TADB_enhanced_cis.bed`: per-gene TADB-enhanced cis windows (`#chr`, `start`, `end`, `gene_id`).\n",
-    "- `extended_TADB.bed`: extended TAD boundaries (`#chr`, `start`, `end`, `index`)."
+    "- Generalized TAD: `generalized_TAD.tsv`\n",
+    "- Generalized TADB: `generalized_TADB.tsv`\n",
+    "- TADB-enhanced cis window: `TADB_enhanced_cis.bed`\n",
+    "- Extended TADB: `extended_TADB.bed`\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4cda5fcd",
+   "id": "5bcd31fb",
    "metadata": {
     "kernel": "SoS"
    },
    "source": [
-    "## Steps"
+    "## Detailed walkthrough\n",
+    "\n",
+    "The `default` workflow constructs the generalized TADs and TADB-enhanced cis windows in a single pass: it manages TAD redundancy (recursive merge of overlapping/neighboring TADs), derives generalized TAD boundaries, then builds the TADB-enhanced cis windows and extended TADBs by joining those boundaries with gene coordinates. The cells below document this process step by step for reference and reproducibility.\n",
+    "\n",
+    "**Timing:** ~varies on typical compute infrastructure.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c6d2e4e7",
+   "id": "f09655bf-4aac-4264-8b03-9fa9df8918fb",
    "metadata": {
     "kernel": "SoS"
    },
    "source": [
-    "**Step 1.** Run the consolidated `default` workflow. It manages TAD redundancy (recursive merge of overlapping TADs), derives generalized TAD boundaries, and builds the TADB-enhanced cis windows and extended TADBs in a single pass."
+    "## Step 1: Manage TAD Redundancy"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "b838c6d5-8a8d-431a-b0ac-8f254fcc6e7c",
+   "metadata": {
+    "kernel": "SoS"
+   },
    "source": [
-    "**Timing:** ~varies on typical compute infrastructure."
+    "```\n",
+    "# merge the TADs to one file\n",
+    "cat ../../reference_data/TAD/Hippocampus_Schmitt2016-raw_TADs.txt ../../reference_data/TAD/Cortex_DLPFC_Schmitt2016-raw_TADs.txt > ../../reference_data/TAD/brain_TADs.txt\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "192a2a2d",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "The merged TADs are processed in several passes. First, neighboring TABs are merged, including a step that manually corrects the start and end position of each chromosome. Preliminary merges then remove exact duplicates (same chromosome, start, and end). Next, the overlap between TADs is determined — the overlap with the preceding TAD, the overlap with the following TAD, and TADs entirely contained within another TAD — with two overlap values tracked per TAD (preceding and following). Finally, TADs are merged recursively: each TAD is extended to the right boundary of the last TAD and to the left boundary of the next, repeating until no further merging is possible, which yields the set of generalized TADs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f149b097-05d1-4cdb-931e-a2c667389f62",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Step 2: Generate TADB-enhanced cis windows and extended TADBs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "617c7efe",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "### How to find boundaries and build TADB\n",
+    "\n",
+    "After the generalized TAD is built, the intervals between TADs are not simply the boundaries. Most generalized TADs have a structure like the one below.\n",
+    "\n",
+    "![](TADB_idealcase.png)\n",
+    "\n",
+    "The black line is the genome, and the red and blue shaded triangles are TAD results from hippocampus and cortex, respectively; in the code they are denoted as **specific TADs** because they are specific to one tissue. The two specific TAD lists (blue and red) do not have overlaps internally, but when pooled together red and blue can overlap. If their overlap exceeds **80%**, they are merged into a larger TAD called a **generalized TAD** (green triangle), giving the generalized TAD list.\n",
+    "\n",
+    "It is not necessary that specific TADs line up this way. For example, if two specific TADs **do not overlap enough**, or if a specific TAD does not overlap any other TAD, each forms a generalized TAD **solely**, as shown below.\n",
+    "\n",
+    "![](sole_case.png)\n",
+    "\n",
+    "At the boundary of a generalized TAD there are regions not covered by either of the two specific TADs, meaning not all information belongs to a TAD; these can belong to a TAB (boundary region). A **generalized TAB** is defined to include not only the intervals but also the ambiguous regions, shown as the **yellow** triangles below. To form TADBs, the generalized TAD is combined with its adjacent TABs — in the diagram, for generalized TAD2 the TADB is (generalized) TAB1 + TAD2 + TAB2.\n",
+    "\n",
+    "![](TADB_diagram.png)\n",
+    "\n",
+    "Generalized TADs formed from a single specific TAD have no ambiguous regions, so their boundaries are also the boundaries of the generalized TAB; under this definition, adjacent generalized TADs such as TAD2 and TAD3 can share the same TADB.\n",
+    "\n",
+    "The strategy is to derive a list of left and right boundaries. For a generalized TAD formed by two or more specific TADs, the left boundary is the start of the second specific TAD; for one formed from a single TAD, the left boundary is just that TAD's start. Right boundaries are defined symmetrically using the second-to-last specific TAD's end. Left boundaries are shown as red vertical lines and right boundaries as blue vertical lines, and the definition also covers more complicated cases.\n",
+    "\n",
+    "![](left_right.png)\n",
+    "\n",
+    "Given these boundaries, a TADB is built by extending the left side of a generalized TAD to the last right boundary (including the start of the chromosome, 0) and the right side to the next left boundary (including the end of each chromosome)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b32678a",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "#### Build TADBs and remove redundancy\n",
+    "\n",
+    "The procedure produces 1401 generalized TADs in total. Gene start and end coordinates are obtained from the gene-model GTF. Most generalized TADs are formed from 2 specific TADs, though some are formed from as many as 4; the same boundary strategy applies in every case, and generalized TADs formed from one versus more specific TADs have different boundary definitions.\n",
+    "\n",
+    "Left boundaries should include the **end** of the chromosome, because the left boundary of a TAD is the right boundary of the former TADB; the last TADB takes the end of the chromosome as its right boundary. Each TAD is then mapped to the closest left/right boundary. After extending to TADBs the number of regions does not change, as expected, but after merging some TADBs become fully covered by other TADBs — for example, the TADB formed by generalized TAD1 can be entirely contained within the extension of generalized TAD2 (blue: right boundary, red: left boundary).\n",
+    "\n",
+    "![](overlap.png)\n",
+    "\n",
+    "Two steps are therefore used to exclude TADBs that are fully covered by another single TADB (including the case where two TADBs are identical). After removing subsets and duplicates, 1381 TADBs remain."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98e6449f",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "#### Length distribution\n",
+    "\n",
+    "The average length of the generalized TADs is a little shorter than 2Mb. The generalized TADBs have an average length a little longer than 2Mb, and the number of extreme cases increases; as expected, a TADB is longer than its TAD because it also includes the boundaries."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd008081",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "#### Compare TADB and cis windows\n",
+    "\n",
+    "Each TADB covers many genes. For fine-mapping, each gene is assigned a 1Mb cis window (2Mb total), so the next step checks whether the TADBs fully cover the cis windows of the genes inside them. Verifying that every gene is covered by a TADB confirms the TADBs are correct, since they should span the whole genome. The only genes in the full gene list not covered by a TADB are on chromosome Y, MT, or are ERCC spike-ins; these are expected to be absent because the TAD data does not include them. A value of 0 marks a cis window not fully covered by the TADB its gene lies in: even after constructing the TADBs, many genes still have a 1Mb cis window (2Mb total) that extends beyond its TADB region."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b24fdda8",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "#### Construct TADB-enhanced cis windows and extended TADBs\n",
+    "\n",
+    "For each gene, its 1Mb upstream/downstream window (2Mb total) and the TADB it falls in are combined, extending the region outward to the smaller start and the larger end of the two. This yields one extended cis window per gene, most with a length close to or larger than the original 2Mb window, so that every gene maps to an extended cis window and none is left uncovered. Compared with the TADB-enhanced cis window, the extended TADB allows a single gene to belong to multiple extended regions."
    ]
   },
   {
@@ -120,14 +224,65 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acbe0363",
+   "id": "2d12ed03",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Output\n",
+    "\n",
+    "- `generalized_TAD.tsv`: redundancy-managed (merged) generalized TADs (`chr`, `start`, `end`).\n",
+    "- `generalized_TADB.tsv`: generalized TAD boundaries with a `TADB` index.\n",
+    "- `TADB_enhanced_cis.bed`: per-gene TADB-enhanced cis windows (`#chr`, `start`, `end`, `gene_id`).\n",
+    "- `extended_TADB.bed`: extended TAD boundaries (`#chr`, `start`, `end`, `index`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6df2c4d",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Anticipated Results\n",
+    "\n",
+    "The pipeline produces output files in the `output/` subdirectory named after the workflow step. Verify success by checking that output files exist and are non-empty. See the **Output** section above for the expected file names and formats."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9caa725-1aa8-4657-91f7-b9a84406f688",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Troubleshooting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9fbfa3c-4250-4eb4-b73f-af89190277f0",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "| Step | Substep | Problem | Possible Reason | Solution |\n",
+    "|------|---------|---------|------------------|---------|\n",
+    "|  |  |  |  |  |\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a011936e",
    "metadata": {
     "kernel": "SoS"
    },
    "source": [
     "## Workflow implementation\n",
     "\n",
-    "The `[global]` section declares parameters (inputs, output directory, the merge `overlap_cutoff`, and resource options; the empty `container` and the `container=container` task option are kept for parity with the protocol). The single `[default]` section runs the whole pipeline in R: it defines the TAD overlap/merge helpers (`find_TAD_overlap`, `merge_TADs`, `recursive_merge`), produces the generalized TADs, derives left/right boundaries against the hard-coded hg38 chromosome lengths, builds the generalized TADBs, and joins gene coordinates to write the cis-window and extended-TADB BED files. (The original notebook also contains a Python `gtf_to_start_end_bed` helper that derives the gene table from the GTF; here that table is supplied as the `--gene-coords` input.)"
+    "The cells below define the SoS workflow steps invoked by the command above. They are not meant to be edited for routine analysis.\n"
    ]
   },
   {
@@ -399,30 +554,6 @@
     "    write_tsv(extend_TADB, ${_output[\"ext\"]:r})\n",
     "    \n",
     "    cat(\"DONE: generalized TADs =\", nrow(formatted_final_DF), \"| TADB_final =\", nrow(TADB_final), \"| cis windows =\", nrow(extend_cis_ordered), \"| extended TADB =\", nrow(extend_TADB), \"\\n\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "575fe085",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "## Troubleshooting\n",
-    "\n",
-    "| Problem | Likely cause | Fix |\n",
-    "| --- | --- | --- |\n",
-    "| `Error: ... object 'specific' not found` | TAD input not read | Check `--tad-input` path and that it is tab-separated with 3 columns |\n",
-    "| Empty / tiny cis-window output | gene table has no rows on the input chromosomes | Ensure `--gene-coords` covers the same chromosomes as `--tad-input` |\n",
-    "| R package errors (`tidyverse`) | `tidyverse` not installed | Install `tidyverse` in the active R environment |\n",
-    "| Very long runtime | many TADs / genome-wide input | The recursive merge is O(n^2) per round; subset by chromosome for a quick test |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Anticipated Results\n\nThe pipeline produces output files in the `output/` subdirectory named after the workflow step. Verify success by checking that output files exist and are non-empty. See the **Output** section above for the expected file names and formats."
    ]
   }
  ],

--- a/code/SoS/reference_data/reference_data_preparation.ipynb
+++ b/code/SoS/reference_data/reference_data_preparation.ipynb
@@ -15,9 +15,7 @@
     "kernel": "SoS"
    },
    "source": [
-    "This notebook walks through how the reference data used throughout the xQTL protocol is downloaded, formatted, and indexed. Each step calls a single workflow from the `reference_data_preparation.ipynb` module (plus `VCF_QC.ipynb` for the dbSNP step).\n",
-    "\n",
-    "**Timing:** ~4 hours, dominated by the genome download and the STAR/RSEM indexing steps."
+    "## Description"
    ]
   },
   {
@@ -26,14 +24,8 @@
     "kernel": "SoS"
    },
    "source": [
-    "## Description\n",
-    "\n",
-    "The workflow downloads the raw reference files, standardizes the genome and gene annotations, builds the STAR and RSEM alignment indices, and generates the RefFlat, SUPPA, and dbSNP annotations used downstream:\n",
-    "\n",
-    "1. Download the reference genome, gene annotation, ERCC spike-in reference, and dbSNP variants.\n",
-    "2. Format the reference genome and gene annotation (merge ERCC, standardize the FASTA/GTF).\n",
-    "3. Build the STAR and RSEM indices.\n",
-    "4. Generate the RefFlat (Picard), SUPPA (Psichomics), and dbSNP rsID annotations."
+    "We follow the [TOPMed workflow from Broad](https://github.com/broadinstitute/gtex-pipeline/blob/master/TOPMed_RNAseq_pipeline.md) for the aquisition and preparation of reference files for use throughout our pipeline. Our processed reference data may be found [in this folder on Synapse](https://www.synapse.org/#!Synapse:syn36416587). We have included the PDF document compiled by Data Standardization Working Group in the [on Synapse](https://www.synapse.org/#!Synapse:syn36416587) as well as on [ADSP Dashboard](https://www.niagads.org/adsp/content/adspgcadgenomeresources-v2pdf). It contains the reference data to use for the project.\n",
+    "\n"
    ]
   },
   {
@@ -42,43 +34,32 @@
     "kernel": "SoS"
    },
    "source": [
-    "## Input Files\n",
+    "## Command interface\n",
     "\n",
-    "The download steps need only internet access; nothing local is required to begin. The later formatting and indexing steps consume the products of the preceding steps under the `output/reference_data/` working directory.\n",
+    "The pipeline below is organized as a sequence of standalone steps, each with its own narrative and `sos run` command. All steps write into a shared `output/reference_data` working directory so that later steps can consume the artefacts produced by earlier ones."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## 1. Download reference data\n",
     "\n",
-    "| File | Description |\n",
-    "| :--- | :--- |\n",
-    "| `GRCh38_full_analysis_set_plus_decoy_hla.fa` | Reference genome FASTA (downloaded) |\n",
-    "| `Homo_sapiens.GRCh38.103.chr.gtf` | Ensembl gene annotation GTF (downloaded) |\n",
-    "| `ERCC92.fa` / `ERCC92.gtf` | ERCC spike-in reference (downloaded) |\n",
-    "| `00-All.vcf.gz` | dbSNP variant reference (downloaded) |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "## Steps"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "### 1. [Download Reference Data](https://statfungen.github.io/xqtl-protocol/code/reference_data/reference_data_preparation.html#i-download-reference-data)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Timing: ~2 hours"
+    "This step downloads the unmodified source files that every downstream step builds upon: the human reference genome, the Ensembl gene annotation, the ERCC spike-in sequences, and the dbSNP variant call set.\n",
+    "\n",
+    "**Input**: None.\n",
+    "\n",
+    "**Output**:\n",
+    "* `00-All.vcf.gz`\n",
+    "* `00-All.vcf.gz.tbi`\n",
+    "* `ERCC92.fa`\n",
+    "* `ERCC92.gtf`\n",
+    "* `ERCC92.zip`\n",
+    "* `GRCh38_full_analysis_set_plus_decoy_hla.fa`\n",
+    "* `Homo_sapiens.GRCh38.103.chr.gtf`\n",
+    "* `Homo_sapiens.GRCh38.103.chr.gtf.gz`"
    ]
   },
   {
@@ -101,16 +82,19 @@
     "kernel": "SoS"
    },
    "source": [
-    "### 2. [Format Reference Data](https://statfungen.github.io/xqtl-protocol/code/reference_data/reference_data_preparation.html#ii-format-reference-data)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Timing: ~40 min\n"
+    "## 2. Format reference genome\n",
+    "\n",
+    "The downloaded genome is reformatted into the version used by the rest of the protocol: the HLA, ALT and Decoy records are removed because none of the downstream RNA-seq calling components handle them properly, the ERCC spike-in sequences are appended (these do no harm even when ERCC is not part of the RNA-seq library), and the resulting FASTA is indexed.\n",
+    "\n",
+    "**Input**: a reference FASTA file.\n",
+    "\n",
+    "**Output**: a reference FASTA file without HLA, ALT and Decoy but with ERCC:\n",
+    "* `ERCC92.patched.fa`\n",
+    "* `GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.fasta`\n",
+    "* `GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy_ERCC.dict`\n",
+    "* `GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy_ERCC.fasta`\n",
+    "* `GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy_ERCC.fasta.fai`\n",
+    "* `Homo_sapiens.GRCh38.103.chr.reformatted.gtf`"
    ]
   },
   {
@@ -133,7 +117,15 @@
     "kernel": "SoS"
    },
    "source": [
-    "Change the --stranded option to --no-stranded if using un-stranded RNA-seq protocol. "
+    "## 3. Transcript and gene model reference processing\n",
+    "\n",
+    "This step modifies the GTF file for two reasons. First, RSEM requires the GTF to use the same chromosome naming convention (with a `chr` prefix) as the FASTA file; although this can also be addressed with the `--sjdbGTFchrPrefix \"chr\"` option for STAR, the `chr` prefix is added to the GTF for use with RSEM. Second, the gene-model collapsing script `collapse_annotation.py` from GTEx expects the GTF to carry a `transcript_type` attribute rather than `transcript_biotype`; this is renamed here while building the Docker image. ERCC information is also added to the GTF reference as a further customization.\n",
+    "\n",
+    "**Collapsed gene model.** Gene-level expression and eQTLs in the GTEx project are computed on a collapsed gene model (all isoforms of a gene combined into a single transcript), following these rules: transcripts annotated as `retained_intron` or `read_through` are excluded, and transcripts overlapping annotated read-through transcripts may be blacklisted (blacklists for GENCODE v19, v24 and v25 are provided in the GTEx repository; no transcripts were blacklisted for v26); the union of all exon intervals of each gene is taken; and overlapping intervals between genes are excluded. Excluding overlapping regions (step 3) primarily removes genes annotated on both strands that cannot be unambiguously quantified from unstranded RNA-seq; for stranded protocols this step can be skipped with the `--collapse_only` flag. Further documentation is available on the [GTEx Portal](https://gtexportal.org/home/documentationPage#staticTextAnalysisMethods).\n",
+    "\n",
+    "**Input**: an uncompressed GFF3 file (i.e. one that can be read with `cat`) and a GTF file.\n",
+    "\n",
+    "**Output**: a GTF file with a collapsed gene model."
    ]
   },
   {
@@ -157,25 +149,13 @@
     "kernel": "SoS"
    },
    "source": [
-    "### 3. [Format Gene Feature Data](https://statfungen.github.io/xqtl-protocol/code/reference_data/reference_data_preparation.html#iii-format-gene-feature-data)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Timing: ~1min"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Change the --stranded option to --no-stranded if using un-stranded RNA-seq protocol. "
+    "## 4. Gene annotation\n",
+    "\n",
+    "This step assembles the gene annotation used downstream by combining the ERCC GTF, the reformatted Ensembl GTF, and the formatted reference genome into a single coherent annotation set.\n",
+    "\n",
+    "**Input**: a GTF file and an accompanying FASTA file.\n",
+    "\n",
+    "**Output**: the formatted gene annotation reference."
    ]
   },
   {
@@ -200,25 +180,15 @@
     "kernel": "SoS"
    },
    "source": [
-    "### 4. [Generate STAR Index](https://statfungen.github.io/xqtl-protocol/code/reference_data/reference_data_preparation.html#iv-generate-star-index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Timing: ~30 min"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Generate the STAR index without the GTF annotation file to allow for customized read length later in STAR alignment. "
+    "## 5. Generate STAR index\n",
+    "\n",
+    "This step generates the index file used for STAR alignment. The index needs to be generated only once and can then be re-used. **At least 40GB of memory is required.**\n",
+    "\n",
+    "The `gtf` and `fasta` parameters give the paths to the reference sequence and both must be unzipped; the `gtf` should be the one prior to collapsing by gene. The `sjdbOverhang` parameter specifies the length of genomic sequence around each annotated junction used when constructing the splice-junction database; ideally it should equal the read length minus one, where read length is the length of the reads. A value of 100 is used here as recommended by the TOPMed pipeline (see [additional discussion](https://groups.google.com/g/rna-star/c/h9oh10UlvhI/m/BfSPGivUHmsJ)).\n",
+    "\n",
+    "**Input**: a GTF file and an accompanying FASTA file.\n",
+    "\n",
+    "**Output**: an index folder stored in `{cwd}/STAR_Index`, used by STAR."
    ]
   },
   {
@@ -242,25 +212,15 @@
     "kernel": "SoS"
    },
    "source": [
-    "### 5. [Generate RSEM Index](https://statfungen.github.io/xqtl-protocol/code/reference_data/reference_data_preparation.html#v-generate-rsem-index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Timing: ~1min"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Generate RSEM index with the uncollapsed gtf file (without the gene tag in its file name.)\n"
+    "## 6. Generate RSEM index\n",
+    "\n",
+    "This step generates the indexing file used for RSEM. The index needs to be generated only once.\n",
+    "\n",
+    "The `gtf` and `fasta` parameters give the paths to the reference sequence; the `gtf` should be the one prior to collapsing by gene. The `sjdbOverhang` parameter specifies the length of genomic sequence around each annotated junction used when constructing the splice-junction database; ideally it should equal the read length minus one.\n",
+    "\n",
+    "**Input**: a GTF file and an accompanying FASTA file.\n",
+    "\n",
+    "**Output**: an index folder stored in `RSEM_Index`, used by RSEM."
    ]
   },
   {
@@ -283,16 +243,13 @@
     "kernel": "SoS"
    },
    "source": [
-    "### 6. [Generate RefFlat Annotation for Picard](https://statfungen.github.io/xqtl-protocol/code/reference_data/reference_data_preparation.html#vi-generate-refflat-annotation-for-picard)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Timing: ~1min"
+    "## 7. Generate RefFlat annotation\n",
+    "\n",
+    "This file is required by the Picard `CollectRnaSeqMetrics` module, which produces metrics describing the distribution of bases within the transcripts. It calculates the total numbers and fractions of nucleotides within specific genomic regions, including untranslated regions (UTRs), introns, intergenic sequences (between discrete genes), and peptide-coding sequences (exons). The tool also determines the number of bases that pass quality filters specific to Illumina data (PF_BASES).\n",
+    "\n",
+    "**Input**: a GTF file.\n",
+    "\n",
+    "**Output**: a `ref.flat` file."
    ]
   },
   {
@@ -314,16 +271,13 @@
     "kernel": "SoS"
    },
    "source": [
-    "### 7. [Generate SUPPA Annotation for Psichomics](https://statfungen.github.io/xqtl-protocol/code/reference_data/reference_data_preparation.html#vii-generate-suppa-annotation-for-psichomics)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Timing: ~1min"
+    "## 8. Generate SUPPA annotation\n",
+    "\n",
+    "The custom alternative-splicing annotation is generated for psichomics, based on [this tutorial](https://rpubs.com/nuno-agostinho/preparing-AS-annotation); the procedure for generating the local alternative-splicing SUPPA output is documented on the [SUPPA GitHub page](https://github.com/comprna/SUPPA). Because the original annotation provided by the psichomics package uses gene symbols, it is modified here to use Ensembl IDs. The modified annotation is then used for [detecting RNA alternative splicing with psichomics](https://statfungen.github.io/xqtl-protocol/code/molecular_phenotypes/calling/splicing_calling.html).\n",
+    "\n",
+    "**Input**: a GTF file.\n",
+    "\n",
+    "**Output**: a `.SUPPA_annotation.rds` file."
    ]
   },
   {
@@ -345,25 +299,13 @@
     "kernel": "SoS"
    },
    "source": [
-    "### 8. [Extract rsIDs for Known Variants](https://statfungen.github.io/xqtl-protocol/code/reference_data/reference_data_preparation.html#viii-extract-rsids-for-known-variants)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Timing: <30min"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Extract the rsID for the known varriants so that we can distinguish them from the novel variants we had in our study. The procedure/rationale is explained in this post"
+    "## 9. Extract rsIDs and TAD annotation\n",
+    "\n",
+    "The dbSNP call set is processed to extract rsIDs for known variants, producing a lookup used to annotate variants throughout the protocol. The TAD-associated index is built from the topologically associating domains defined in [Wang et al.](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7895846/) to delimit the genotype cis region used for fine-mapping across phenotypes; the TAD dataframe for each cell type and tissue is downloaded from the [hg38 TAD resource](http://3dgenome.fsm.northwestern.edu/publications.html). The TAD file is generated in three steps: the union of TADs across tissues, extension with TAD boundaries, and extension with cis windows.\n",
+    "\n",
+    "**Input**: a `.vcf.gz` file (for rsIDs) and a file containing a list of TADs and a region list (for TAD annotation).\n",
+    "\n",
+    "**Output**: a `.variants.gz` file (rsIDs) and a `.annotation` file (TAD)."
    ]
   },
   {
@@ -381,7 +323,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "kernel": "SoS"
+   },
    "source": [
     "## Output\n",
     "\n",
@@ -400,7 +344,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "kernel": "SoS"
+   },
    "source": [
     "## Anticipated Results\n",
     "\n",
@@ -408,9 +354,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Workflow implementation\n",
+    "\n",
+    "The SoS step definitions below implement the commands described above."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vulnerable-virginia",
    "metadata": {
     "kernel": "SoS"
    },
@@ -436,7 +392,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bright-garlic",
    "metadata": {
     "kernel": "SoS"
    },
@@ -451,7 +406,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "mediterranean-package",
    "metadata": {
     "kernel": "SoS"
    },
@@ -466,7 +420,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "disturbed-understanding",
    "metadata": {
     "kernel": "SoS"
    },
@@ -481,7 +434,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "operating-newman",
    "metadata": {
     "kernel": "SoS"
    },
@@ -497,7 +449,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dying-palestinian",
    "metadata": {
     "kernel": "SoS"
    },
@@ -515,7 +466,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "pointed-moore",
    "metadata": {
     "kernel": "SoS"
    },
@@ -544,7 +494,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tamil-singing",
    "metadata": {
     "kernel": "SoS"
    },
@@ -562,7 +511,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "approved-clearance",
    "metadata": {
     "kernel": "SoS",
     "tags": []
@@ -582,7 +530,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "aggregate-modification",
    "metadata": {
     "kernel": "SoS"
    },
@@ -617,7 +564,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "fourth-mentor",
    "metadata": {
     "kernel": "SoS"
    },
@@ -634,7 +580,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "dependent-breast",
    "metadata": {
     "kernel": "SoS"
    },
@@ -680,7 +625,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "material-johns",
    "metadata": {
     "kernel": "SoS"
    },
@@ -698,7 +642,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "corrected-economy",
    "metadata": {
     "kernel": "SoS"
    },
@@ -730,7 +673,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "automated-width",
    "metadata": {
     "kernel": "SoS"
    },
@@ -756,7 +698,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "strange-strip",
    "metadata": {
     "kernel": "SoS"
    },
@@ -776,7 +717,6 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "cutting-magazine",
    "metadata": {
     "kernel": "SoS"
    },
@@ -794,7 +734,6 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "romantic-workplace",
    "metadata": {
     "kernel": "SoS"
    },
@@ -814,7 +753,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "minute-emphasis",
    "metadata": {
     "kernel": "SoS",
     "tags": []
@@ -965,7 +903,6 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "vulnerable-banner",
    "metadata": {
     "kernel": "SoS",
     "tags": []


### PR DESCRIPTION
Summary
This PR refines the prose/narrative (markdown cells) of 7 SoS protocol notebooks. All executable code cells are byte-for-byte identical to main — I verified this by extracting the source of every code cell from each notebook and diffing against main (all 7 came back code-identical). Only markdown content changed.
Notebooks included (7):

code/SoS/association_scan/TensorQTL/TensorQTL.ipynb
code/SoS/misc/advanced_analysis/1_twas_mr_colocboost.ipynb
code/SoS/misc/data_preprocessing/3_genotype_pca.ipynb
code/SoS/misc/data_preprocessing/4_covariates_preprocessing.ipynb
code/SoS/pecotmr_integration/twas_ctwas.ipynb
code/SoS/reference_data/generalized_TADB.ipynb
code/SoS/reference_data/reference_data_preparation.ipynb

Integrity: Each notebook is valid JSON; code cells unchanged from main; based on current main (includes #1348).
Changes: 7 files changed, 645 insertions(+), 444 deletions(−)
