### PR TITLE
Restore tensorqtl examples

### DIFF
--- a/code/SoS/association_scan/TensorQTL/TensorQTL.ipynb
+++ b/code/SoS/association_scan/TensorQTL/TensorQTL.ipynb
@@ -46,6 +46,137 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "R"
+   },
+   "outputs": [],
+   "source": [
+    "# Load required libraries\n",
+    "library(data.table)\n",
+    "library(genio)\n",
+    "\n",
+    "# ------------------------------------------------------------------\n",
+    "# Example phenotype file (MWE: protocol_example, chr22)\n",
+    "# ------------------------------------------------------------------\n",
+    "# A text file listing one phenotype .bed.gz per chromosome.\n",
+    "pheno_path <- fread(\"output/phenotype/phenotype_by_chrom_for_cis/bulk_rnaseq.phenotype_by_chrom_files.txt\")\n",
+    "head(pheno_path)\n",
+    "\n",
+    "# One chromosome of phenotype data in BED-like format (.bed.gz).\n",
+    "pheno <- fread(\"output/phenotype/phenotype_by_chrom_for_cis/bulk_rnaseq.chr22.bed.gz\")\n",
+    "pheno[1:5, 1:8]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "### Example genotype file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "R"
+   },
+   "outputs": [],
+   "source": [
+    "# ------------------------------------------------------------------\n",
+    "# Example genotype file (MWE: protocol_example)\n",
+    "# ------------------------------------------------------------------\n",
+    "# A text file with two columns: chromosome ID and PLINK prefix path.\n",
+    "geno_path <- fread(\"output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.genotype_by_chrom_files.txt\")\n",
+    "head(geno_path)\n",
+    "\n",
+    "# Read the merged PLINK set (.bed/.bim/.fam) for the toy sample.\n",
+    "plink_data <- read_plink(\"output/plink/protocol_example.genotype.merged.plink_qc\")\n",
+    "genotypes <- plink_data$X\n",
+    "genotypes[1:5, 1:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "### Example covariates file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "R"
+   },
+   "outputs": [],
+   "source": [
+    "# ------------------------------------------------------------------\n",
+    "# Example covariates file (MWE: protocol_example)\n",
+    "# ------------------------------------------------------------------\n",
+    "cov <- fread(\"output/covariate/protocol_example.rnaseq.bed.protocol_example.covariates.protocol_example.genotype.merged.plink_qc.plink_qc.prune.pca.Marchenko_PC.gz\")\n",
+    "cov[, 1:5]\n",
+    "dim(cov)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "### Example customized cis window file (Optional)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "R"
+   },
+   "outputs": [],
+   "source": [
+    "# ------------------------------------------------------------------\n",
+    "# Example customized cis-window file (Optional)\n",
+    "# ------------------------------------------------------------------\n",
+    "# Gene-level cis-window (start/end) defining the SNP search region per gene.\n",
+    "# Omit to use --window for a symmetric +/-1Mb window around each gene TSS.\n",
+    "window <- fread(\"data/mnm_genes/extended_TADB.bed\")\n",
+    "head(window)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "### Example interaction file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "R"
+   },
+   "outputs": [],
+   "source": [
+    "# ------------------------------------------------------------------\n",
+    "# Example interaction file (Optional, for iQTL analysis)\n",
+    "# ------------------------------------------------------------------\n",
+    "# Provide an interaction term as a separate file via --interaction\n",
+    "# when it is not already part of the covariate file.\n",
+    "int <- fread(\"data/ROSMAP_interaction_example.tsv\")\n",
+    "head(int)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "kernel": "SoS"

--- a/code/SoS/association_scan/TensorQTL/TensorQTL.ipynb
+++ b/code/SoS/association_scan/TensorQTL/TensorQTL.ipynb
@@ -47,17 +47,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "kernel": "R"
-   },
-   "outputs": [],
-   "source": [
-    "out <- \"/restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example\""
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 7,
    "metadata": {
     "kernel": "R"

--- a/code/SoS/association_scan/TensorQTL/TensorQTL.ipynb
+++ b/code/SoS/association_scan/TensorQTL/TensorQTL.ipynb
@@ -47,11 +47,125 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "kernel": "R"
    },
    "outputs": [],
+   "source": [
+    "out <- \"/restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "kernel": "R"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A data.table: 1 × 2</caption>\n",
+       "<thead>\n",
+       "\t<tr><th scope=col>#id</th><th scope=col>#dir</th></tr>\n",
+       "\t<tr><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>22</td><td>output/phenotype/phenotype_by_chrom_for_cis/bulk_rnaseq.chr22.bed.gz</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A data.table: 1 × 2\n",
+       "\\begin{tabular}{ll}\n",
+       " \\#id & \\#dir\\\\\n",
+       " <int> & <chr>\\\\\n",
+       "\\hline\n",
+       "\t 22 & output/phenotype/phenotype\\_by\\_chrom\\_for\\_cis/bulk\\_rnaseq.chr22.bed.gz\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A data.table: 1 × 2\n",
+       "\n",
+       "| #id &lt;int&gt; | #dir &lt;chr&gt; |\n",
+       "|---|---|\n",
+       "| 22 | output/phenotype/phenotype_by_chrom_for_cis/bulk_rnaseq.chr22.bed.gz |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  #id #dir                                                                \n",
+       "1 22  output/phenotype/phenotype_by_chrom_for_cis/bulk_rnaseq.chr22.bed.gz"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A data.table: 5 × 8</caption>\n",
+       "<thead>\n",
+       "\t<tr><th scope=col>#chr</th><th scope=col>start</th><th scope=col>end</th><th scope=col>ID</th><th scope=col>SAMPLE_001</th><th scope=col>SAMPLE_002</th><th scope=col>SAMPLE_003</th><th scope=col>SAMPLE_004</th></tr>\n",
+       "\t<tr><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>chr22</td><td>10939387</td><td>10961337</td><td>ENSG00000283047</td><td>37.076840</td><td>0.00000</td><td>5.583274</td><td> 0.0000000</td></tr>\n",
+       "\t<tr><td>chr22</td><td>15528191</td><td>15529138</td><td>ENSG00000130538</td><td> 0.000000</td><td>1.08358</td><td>8.913977</td><td> 4.0885045</td></tr>\n",
+       "\t<tr><td>chr22</td><td>15611758</td><td>15613095</td><td>ENSG00000231565</td><td> 5.978084</td><td>0.00000</td><td>2.637113</td><td>10.4666167</td></tr>\n",
+       "\t<tr><td>chr22</td><td>15615401</td><td>15615577</td><td>ENSG00000226474</td><td> 0.000000</td><td>0.00000</td><td>2.870204</td><td> 0.0000000</td></tr>\n",
+       "\t<tr><td>chr22</td><td>15749155</td><td>15750824</td><td>ENSG00000235992</td><td> 5.820253</td><td>0.00000</td><td>0.000000</td><td> 0.5868365</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A data.table: 5 × 8\n",
+       "\\begin{tabular}{llllllll}\n",
+       " \\#chr & start & end & ID & SAMPLE\\_001 & SAMPLE\\_002 & SAMPLE\\_003 & SAMPLE\\_004\\\\\n",
+       " <chr> & <int> & <int> & <chr> & <dbl> & <dbl> & <dbl> & <dbl>\\\\\n",
+       "\\hline\n",
+       "\t chr22 & 10939387 & 10961337 & ENSG00000283047 & 37.076840 & 0.00000 & 5.583274 &  0.0000000\\\\\n",
+       "\t chr22 & 15528191 & 15529138 & ENSG00000130538 &  0.000000 & 1.08358 & 8.913977 &  4.0885045\\\\\n",
+       "\t chr22 & 15611758 & 15613095 & ENSG00000231565 &  5.978084 & 0.00000 & 2.637113 & 10.4666167\\\\\n",
+       "\t chr22 & 15615401 & 15615577 & ENSG00000226474 &  0.000000 & 0.00000 & 2.870204 &  0.0000000\\\\\n",
+       "\t chr22 & 15749155 & 15750824 & ENSG00000235992 &  5.820253 & 0.00000 & 0.000000 &  0.5868365\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A data.table: 5 × 8\n",
+       "\n",
+       "| #chr &lt;chr&gt; | start &lt;int&gt; | end &lt;int&gt; | ID &lt;chr&gt; | SAMPLE_001 &lt;dbl&gt; | SAMPLE_002 &lt;dbl&gt; | SAMPLE_003 &lt;dbl&gt; | SAMPLE_004 &lt;dbl&gt; |\n",
+       "|---|---|---|---|---|---|---|---|\n",
+       "| chr22 | 10939387 | 10961337 | ENSG00000283047 | 37.076840 | 0.00000 | 5.583274 |  0.0000000 |\n",
+       "| chr22 | 15528191 | 15529138 | ENSG00000130538 |  0.000000 | 1.08358 | 8.913977 |  4.0885045 |\n",
+       "| chr22 | 15611758 | 15613095 | ENSG00000231565 |  5.978084 | 0.00000 | 2.637113 | 10.4666167 |\n",
+       "| chr22 | 15615401 | 15615577 | ENSG00000226474 |  0.000000 | 0.00000 | 2.870204 |  0.0000000 |\n",
+       "| chr22 | 15749155 | 15750824 | ENSG00000235992 |  5.820253 | 0.00000 | 0.000000 |  0.5868365 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  #chr  start    end      ID              SAMPLE_001 SAMPLE_002 SAMPLE_003\n",
+       "1 chr22 10939387 10961337 ENSG00000283047 37.076840  0.00000    5.583274  \n",
+       "2 chr22 15528191 15529138 ENSG00000130538  0.000000  1.08358    8.913977  \n",
+       "3 chr22 15611758 15613095 ENSG00000231565  5.978084  0.00000    2.637113  \n",
+       "4 chr22 15615401 15615577 ENSG00000226474  0.000000  0.00000    2.870204  \n",
+       "5 chr22 15749155 15750824 ENSG00000235992  5.820253  0.00000    0.000000  \n",
+       "  SAMPLE_004\n",
+       "1  0.0000000\n",
+       "2  4.0885045\n",
+       "3 10.4666167\n",
+       "4  0.0000000\n",
+       "5  0.5868365"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Load required libraries\n",
     "library(data.table)\n",
@@ -80,17 +194,151 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "kernel": "R"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A data.table: 6 × 2</caption>\n",
+       "<thead>\n",
+       "\t<tr><th scope=col>#id</th><th scope=col>#path</th></tr>\n",
+       "\t<tr><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><td> 2</td><td>/restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.2.bed </td></tr>\n",
+       "\t<tr><td> 6</td><td>/restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.6.bed </td></tr>\n",
+       "\t<tr><td>13</td><td>/restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.13.bed</td></tr>\n",
+       "\t<tr><td> 8</td><td>/restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.8.bed </td></tr>\n",
+       "\t<tr><td> 7</td><td>/restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.7.bed </td></tr>\n",
+       "\t<tr><td>11</td><td>/restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.11.bed</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A data.table: 6 × 2\n",
+       "\\begin{tabular}{ll}\n",
+       " \\#id & \\#path\\\\\n",
+       " <int> & <chr>\\\\\n",
+       "\\hline\n",
+       "\t  2 & /restricted/projectnb/xqtl/jaempawi/xqtl\\_protocol/toy\\_example/output/genotype\\_by\\_chrom/protocol\\_example.genotype.merged.plink\\_qc.2.bed \\\\\n",
+       "\t  6 & /restricted/projectnb/xqtl/jaempawi/xqtl\\_protocol/toy\\_example/output/genotype\\_by\\_chrom/protocol\\_example.genotype.merged.plink\\_qc.6.bed \\\\\n",
+       "\t 13 & /restricted/projectnb/xqtl/jaempawi/xqtl\\_protocol/toy\\_example/output/genotype\\_by\\_chrom/protocol\\_example.genotype.merged.plink\\_qc.13.bed\\\\\n",
+       "\t  8 & /restricted/projectnb/xqtl/jaempawi/xqtl\\_protocol/toy\\_example/output/genotype\\_by\\_chrom/protocol\\_example.genotype.merged.plink\\_qc.8.bed \\\\\n",
+       "\t  7 & /restricted/projectnb/xqtl/jaempawi/xqtl\\_protocol/toy\\_example/output/genotype\\_by\\_chrom/protocol\\_example.genotype.merged.plink\\_qc.7.bed \\\\\n",
+       "\t 11 & /restricted/projectnb/xqtl/jaempawi/xqtl\\_protocol/toy\\_example/output/genotype\\_by\\_chrom/protocol\\_example.genotype.merged.plink\\_qc.11.bed\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A data.table: 6 × 2\n",
+       "\n",
+       "| #id &lt;int&gt; | #path &lt;chr&gt; |\n",
+       "|---|---|\n",
+       "|  2 | /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.2.bed  |\n",
+       "|  6 | /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.6.bed  |\n",
+       "| 13 | /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.13.bed |\n",
+       "|  8 | /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.8.bed  |\n",
+       "|  7 | /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.7.bed  |\n",
+       "| 11 | /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.11.bed |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  #id\n",
+       "1  2 \n",
+       "2  6 \n",
+       "3 13 \n",
+       "4  8 \n",
+       "5  7 \n",
+       "6 11 \n",
+       "  #path                                                                                                                                  \n",
+       "1 /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.2.bed \n",
+       "2 /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.6.bed \n",
+       "3 /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.13.bed\n",
+       "4 /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.8.bed \n",
+       "5 /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.7.bed \n",
+       "6 /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.11.bed"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Reading: /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/plink/protocol_example.genotype.merged.plink_qc.bim\n",
+      "\n",
+      "Reading: /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/plink/protocol_example.genotype.merged.plink_qc.fam\n",
+      "\n",
+      "Reading: /restricted/projectnb/xqtl/jaempawi/xqtl_protocol/toy_example/output/plink/protocol_example.genotype.merged.plink_qc.bed\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A matrix: 5 × 5 of type int</caption>\n",
+       "<thead>\n",
+       "\t<tr><th></th><th scope=col>SAMPLE_001</th><th scope=col>SAMPLE_002</th><th scope=col>SAMPLE_003</th><th scope=col>SAMPLE_004</th><th scope=col>SAMPLE_005</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><th scope=row>chr1:113886_CTCTT_C</th><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>\n",
+       "\t<tr><th scope=row>chr1:191223_C_*</th><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>\n",
+       "\t<tr><th scope=row>chr1:191223_C_G</th><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>\n",
+       "\t<tr><th scope=row>chr1:191223_C_T</th><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>\n",
+       "\t<tr><th scope=row>chr1:275436_A_G</th><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A matrix: 5 × 5 of type int\n",
+       "\\begin{tabular}{r|lllll}\n",
+       "  & SAMPLE\\_001 & SAMPLE\\_002 & SAMPLE\\_003 & SAMPLE\\_004 & SAMPLE\\_005\\\\\n",
+       "\\hline\n",
+       "\tchr1:113886\\_CTCTT\\_C & 0 & 0 & 0 & 0 & 0\\\\\n",
+       "\tchr1:191223\\_C\\_* & 0 & 0 & 0 & 0 & 0\\\\\n",
+       "\tchr1:191223\\_C\\_G & 0 & 0 & 0 & 0 & 0\\\\\n",
+       "\tchr1:191223\\_C\\_T & 0 & 0 & 0 & 0 & 0\\\\\n",
+       "\tchr1:275436\\_A\\_G & 0 & 0 & 0 & 0 & 0\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A matrix: 5 × 5 of type int\n",
+       "\n",
+       "| <!--/--> | SAMPLE_001 | SAMPLE_002 | SAMPLE_003 | SAMPLE_004 | SAMPLE_005 |\n",
+       "|---|---|---|---|---|---|\n",
+       "| chr1:113886_CTCTT_C | 0 | 0 | 0 | 0 | 0 |\n",
+       "| chr1:191223_C_* | 0 | 0 | 0 | 0 | 0 |\n",
+       "| chr1:191223_C_G | 0 | 0 | 0 | 0 | 0 |\n",
+       "| chr1:191223_C_T | 0 | 0 | 0 | 0 | 0 |\n",
+       "| chr1:275436_A_G | 0 | 0 | 0 | 0 | 0 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "                    SAMPLE_001 SAMPLE_002 SAMPLE_003 SAMPLE_004 SAMPLE_005\n",
+       "chr1:113886_CTCTT_C 0          0          0          0          0         \n",
+       "chr1:191223_C_*     0          0          0          0          0         \n",
+       "chr1:191223_C_G     0          0          0          0          0         \n",
+       "chr1:191223_C_T     0          0          0          0          0         \n",
+       "chr1:275436_A_G     0          0          0          0          0         "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# ------------------------------------------------------------------\n",
     "# Example genotype file (MWE: protocol_example)\n",
     "# ------------------------------------------------------------------\n",
     "# A text file with two columns: chromosome ID and PLINK prefix path.\n",
-    "geno_path <- fread(\"output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.genotype_by_chrom_files.txt\")\n",
+    "geno_path <- fread(file.path(output/genotype_by_chrom/protocol_example.genotype.merged.plink_qc.genotype_by_chrom_files.txt\")\n",
     "head(geno_path)\n",
     "\n",
     "# Read the merged PLINK set (.bed/.bim/.fam) for the toy sample.\n",
@@ -110,11 +358,189 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "kernel": "R"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A data.table: 28 × 5</caption>\n",
+       "<thead>\n",
+       "\t<tr><th scope=col>#id</th><th scope=col>SAMPLE_001</th><th scope=col>SAMPLE_002</th><th scope=col>SAMPLE_003</th><th scope=col>SAMPLE_004</th></tr>\n",
+       "\t<tr><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>msex             </td><td> 1.000000000</td><td> 1.00000000</td><td> 1.00000000</td><td> 1.000000000</td></tr>\n",
+       "\t<tr><td>age_death        </td><td>90.970000000</td><td>80.24000000</td><td>83.90000000</td><td>74.100000000</td></tr>\n",
+       "\t<tr><td>pmi              </td><td>10.570000000</td><td> 7.87000000</td><td> 9.93000000</td><td> 2.910000000</td></tr>\n",
+       "\t<tr><td>study            </td><td> 1.000000000</td><td> 0.00000000</td><td> 0.00000000</td><td> 0.000000000</td></tr>\n",
+       "\t<tr><td>PC1              </td><td>-0.233468563</td><td> 0.01961037</td><td> 0.11352412</td><td>-0.040027540</td></tr>\n",
+       "\t<tr><td>PC2              </td><td> 0.327658887</td><td> 0.04553162</td><td>-0.09470268</td><td>-0.146030127</td></tr>\n",
+       "\t<tr><td>PC3              </td><td> 0.098807354</td><td> 0.16302273</td><td> 0.04634796</td><td> 0.026222852</td></tr>\n",
+       "\t<tr><td>PC4              </td><td>-0.330900271</td><td> 0.14254433</td><td> 0.20275994</td><td>-0.001605085</td></tr>\n",
+       "\t<tr><td>PC5              </td><td>-0.310150069</td><td> 0.10916400</td><td>-0.18238419</td><td>-0.120223005</td></tr>\n",
+       "\t<tr><td>PC6              </td><td>-0.218843913</td><td>-0.16840993</td><td>-0.05711533</td><td>-0.221893629</td></tr>\n",
+       "\t<tr><td>PC7              </td><td>-0.040665022</td><td> 0.07576872</td><td> 0.14606728</td><td> 0.136076636</td></tr>\n",
+       "\t<tr><td>PC8              </td><td>-0.286365603</td><td> 0.14011839</td><td>-0.08323989</td><td> 0.040693345</td></tr>\n",
+       "\t<tr><td>PC9              </td><td> 0.078883981</td><td> 0.14174392</td><td> 0.13033626</td><td> 0.332998336</td></tr>\n",
+       "\t<tr><td>PC10             </td><td>-0.151439052</td><td>-0.08918759</td><td> 0.25286117</td><td>-0.152520170</td></tr>\n",
+       "\t<tr><td>PC11             </td><td> 0.118499177</td><td>-0.05618921</td><td>-0.18365505</td><td>-0.038165749</td></tr>\n",
+       "\t<tr><td>PC12             </td><td> 0.053282287</td><td>-0.07951395</td><td> 0.05349163</td><td>-0.081934005</td></tr>\n",
+       "\t<tr><td>PC13             </td><td> 0.115028477</td><td>-0.01330522</td><td>-0.01534750</td><td>-0.070994143</td></tr>\n",
+       "\t<tr><td>PC14             </td><td> 0.087845445</td><td>-0.26853232</td><td>-0.15027729</td><td> 0.218599476</td></tr>\n",
+       "\t<tr><td>PC15             </td><td> 0.001030374</td><td> 0.07595356</td><td>-0.08898327</td><td>-0.181299348</td></tr>\n",
+       "\t<tr><td>Hidden_Factor_PC1</td><td> 0.851879348</td><td> 0.98406483</td><td> 5.18812380</td><td>-5.667832700</td></tr>\n",
+       "\t<tr><td>Hidden_Factor_PC2</td><td>-2.825894932</td><td> 1.69447908</td><td> 0.06854215</td><td>-4.619987817</td></tr>\n",
+       "\t<tr><td>Hidden_Factor_PC3</td><td> 3.763782166</td><td>-0.80512535</td><td>-5.77247349</td><td>-3.825334825</td></tr>\n",
+       "\t<tr><td>Hidden_Factor_PC4</td><td>-1.301340188</td><td> 3.15633800</td><td> 2.42980902</td><td>-3.266057955</td></tr>\n",
+       "\t<tr><td>Hidden_Factor_PC5</td><td> 0.556485272</td><td>-1.26228531</td><td>-3.94541314</td><td> 2.110667490</td></tr>\n",
+       "\t<tr><td>Hidden_Factor_PC6</td><td>-4.493764002</td><td>-0.11490919</td><td>-2.51105454</td><td> 0.278112795</td></tr>\n",
+       "\t<tr><td>Hidden_Factor_PC7</td><td> 2.846210676</td><td>-0.42143392</td><td> 0.34488558</td><td>-3.151865035</td></tr>\n",
+       "\t<tr><td>Hidden_Factor_PC8</td><td>-1.876624232</td><td>-9.65305786</td><td> 4.25303685</td><td>-1.043104423</td></tr>\n",
+       "\t<tr><td>Hidden_Factor_PC9</td><td> 3.126759781</td><td> 0.48805759</td><td> 5.52493678</td><td> 1.428784448</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A data.table: 28 × 5\n",
+       "\\begin{tabular}{lllll}\n",
+       " \\#id & SAMPLE\\_001 & SAMPLE\\_002 & SAMPLE\\_003 & SAMPLE\\_004\\\\\n",
+       " <chr> & <dbl> & <dbl> & <dbl> & <dbl>\\\\\n",
+       "\\hline\n",
+       "\t msex              &  1.000000000 &  1.00000000 &  1.00000000 &  1.000000000\\\\\n",
+       "\t age\\_death         & 90.970000000 & 80.24000000 & 83.90000000 & 74.100000000\\\\\n",
+       "\t pmi               & 10.570000000 &  7.87000000 &  9.93000000 &  2.910000000\\\\\n",
+       "\t study             &  1.000000000 &  0.00000000 &  0.00000000 &  0.000000000\\\\\n",
+       "\t PC1               & -0.233468563 &  0.01961037 &  0.11352412 & -0.040027540\\\\\n",
+       "\t PC2               &  0.327658887 &  0.04553162 & -0.09470268 & -0.146030127\\\\\n",
+       "\t PC3               &  0.098807354 &  0.16302273 &  0.04634796 &  0.026222852\\\\\n",
+       "\t PC4               & -0.330900271 &  0.14254433 &  0.20275994 & -0.001605085\\\\\n",
+       "\t PC5               & -0.310150069 &  0.10916400 & -0.18238419 & -0.120223005\\\\\n",
+       "\t PC6               & -0.218843913 & -0.16840993 & -0.05711533 & -0.221893629\\\\\n",
+       "\t PC7               & -0.040665022 &  0.07576872 &  0.14606728 &  0.136076636\\\\\n",
+       "\t PC8               & -0.286365603 &  0.14011839 & -0.08323989 &  0.040693345\\\\\n",
+       "\t PC9               &  0.078883981 &  0.14174392 &  0.13033626 &  0.332998336\\\\\n",
+       "\t PC10              & -0.151439052 & -0.08918759 &  0.25286117 & -0.152520170\\\\\n",
+       "\t PC11              &  0.118499177 & -0.05618921 & -0.18365505 & -0.038165749\\\\\n",
+       "\t PC12              &  0.053282287 & -0.07951395 &  0.05349163 & -0.081934005\\\\\n",
+       "\t PC13              &  0.115028477 & -0.01330522 & -0.01534750 & -0.070994143\\\\\n",
+       "\t PC14              &  0.087845445 & -0.26853232 & -0.15027729 &  0.218599476\\\\\n",
+       "\t PC15              &  0.001030374 &  0.07595356 & -0.08898327 & -0.181299348\\\\\n",
+       "\t Hidden\\_Factor\\_PC1 &  0.851879348 &  0.98406483 &  5.18812380 & -5.667832700\\\\\n",
+       "\t Hidden\\_Factor\\_PC2 & -2.825894932 &  1.69447908 &  0.06854215 & -4.619987817\\\\\n",
+       "\t Hidden\\_Factor\\_PC3 &  3.763782166 & -0.80512535 & -5.77247349 & -3.825334825\\\\\n",
+       "\t Hidden\\_Factor\\_PC4 & -1.301340188 &  3.15633800 &  2.42980902 & -3.266057955\\\\\n",
+       "\t Hidden\\_Factor\\_PC5 &  0.556485272 & -1.26228531 & -3.94541314 &  2.110667490\\\\\n",
+       "\t Hidden\\_Factor\\_PC6 & -4.493764002 & -0.11490919 & -2.51105454 &  0.278112795\\\\\n",
+       "\t Hidden\\_Factor\\_PC7 &  2.846210676 & -0.42143392 &  0.34488558 & -3.151865035\\\\\n",
+       "\t Hidden\\_Factor\\_PC8 & -1.876624232 & -9.65305786 &  4.25303685 & -1.043104423\\\\\n",
+       "\t Hidden\\_Factor\\_PC9 &  3.126759781 &  0.48805759 &  5.52493678 &  1.428784448\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A data.table: 28 × 5\n",
+       "\n",
+       "| #id &lt;chr&gt; | SAMPLE_001 &lt;dbl&gt; | SAMPLE_002 &lt;dbl&gt; | SAMPLE_003 &lt;dbl&gt; | SAMPLE_004 &lt;dbl&gt; |\n",
+       "|---|---|---|---|---|\n",
+       "| msex              |  1.000000000 |  1.00000000 |  1.00000000 |  1.000000000 |\n",
+       "| age_death         | 90.970000000 | 80.24000000 | 83.90000000 | 74.100000000 |\n",
+       "| pmi               | 10.570000000 |  7.87000000 |  9.93000000 |  2.910000000 |\n",
+       "| study             |  1.000000000 |  0.00000000 |  0.00000000 |  0.000000000 |\n",
+       "| PC1               | -0.233468563 |  0.01961037 |  0.11352412 | -0.040027540 |\n",
+       "| PC2               |  0.327658887 |  0.04553162 | -0.09470268 | -0.146030127 |\n",
+       "| PC3               |  0.098807354 |  0.16302273 |  0.04634796 |  0.026222852 |\n",
+       "| PC4               | -0.330900271 |  0.14254433 |  0.20275994 | -0.001605085 |\n",
+       "| PC5               | -0.310150069 |  0.10916400 | -0.18238419 | -0.120223005 |\n",
+       "| PC6               | -0.218843913 | -0.16840993 | -0.05711533 | -0.221893629 |\n",
+       "| PC7               | -0.040665022 |  0.07576872 |  0.14606728 |  0.136076636 |\n",
+       "| PC8               | -0.286365603 |  0.14011839 | -0.08323989 |  0.040693345 |\n",
+       "| PC9               |  0.078883981 |  0.14174392 |  0.13033626 |  0.332998336 |\n",
+       "| PC10              | -0.151439052 | -0.08918759 |  0.25286117 | -0.152520170 |\n",
+       "| PC11              |  0.118499177 | -0.05618921 | -0.18365505 | -0.038165749 |\n",
+       "| PC12              |  0.053282287 | -0.07951395 |  0.05349163 | -0.081934005 |\n",
+       "| PC13              |  0.115028477 | -0.01330522 | -0.01534750 | -0.070994143 |\n",
+       "| PC14              |  0.087845445 | -0.26853232 | -0.15027729 |  0.218599476 |\n",
+       "| PC15              |  0.001030374 |  0.07595356 | -0.08898327 | -0.181299348 |\n",
+       "| Hidden_Factor_PC1 |  0.851879348 |  0.98406483 |  5.18812380 | -5.667832700 |\n",
+       "| Hidden_Factor_PC2 | -2.825894932 |  1.69447908 |  0.06854215 | -4.619987817 |\n",
+       "| Hidden_Factor_PC3 |  3.763782166 | -0.80512535 | -5.77247349 | -3.825334825 |\n",
+       "| Hidden_Factor_PC4 | -1.301340188 |  3.15633800 |  2.42980902 | -3.266057955 |\n",
+       "| Hidden_Factor_PC5 |  0.556485272 | -1.26228531 | -3.94541314 |  2.110667490 |\n",
+       "| Hidden_Factor_PC6 | -4.493764002 | -0.11490919 | -2.51105454 |  0.278112795 |\n",
+       "| Hidden_Factor_PC7 |  2.846210676 | -0.42143392 |  0.34488558 | -3.151865035 |\n",
+       "| Hidden_Factor_PC8 | -1.876624232 | -9.65305786 |  4.25303685 | -1.043104423 |\n",
+       "| Hidden_Factor_PC9 |  3.126759781 |  0.48805759 |  5.52493678 |  1.428784448 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "   #id               SAMPLE_001   SAMPLE_002  SAMPLE_003  SAMPLE_004  \n",
+       "1  msex               1.000000000  1.00000000  1.00000000  1.000000000\n",
+       "2  age_death         90.970000000 80.24000000 83.90000000 74.100000000\n",
+       "3  pmi               10.570000000  7.87000000  9.93000000  2.910000000\n",
+       "4  study              1.000000000  0.00000000  0.00000000  0.000000000\n",
+       "5  PC1               -0.233468563  0.01961037  0.11352412 -0.040027540\n",
+       "6  PC2                0.327658887  0.04553162 -0.09470268 -0.146030127\n",
+       "7  PC3                0.098807354  0.16302273  0.04634796  0.026222852\n",
+       "8  PC4               -0.330900271  0.14254433  0.20275994 -0.001605085\n",
+       "9  PC5               -0.310150069  0.10916400 -0.18238419 -0.120223005\n",
+       "10 PC6               -0.218843913 -0.16840993 -0.05711533 -0.221893629\n",
+       "11 PC7               -0.040665022  0.07576872  0.14606728  0.136076636\n",
+       "12 PC8               -0.286365603  0.14011839 -0.08323989  0.040693345\n",
+       "13 PC9                0.078883981  0.14174392  0.13033626  0.332998336\n",
+       "14 PC10              -0.151439052 -0.08918759  0.25286117 -0.152520170\n",
+       "15 PC11               0.118499177 -0.05618921 -0.18365505 -0.038165749\n",
+       "16 PC12               0.053282287 -0.07951395  0.05349163 -0.081934005\n",
+       "17 PC13               0.115028477 -0.01330522 -0.01534750 -0.070994143\n",
+       "18 PC14               0.087845445 -0.26853232 -0.15027729  0.218599476\n",
+       "19 PC15               0.001030374  0.07595356 -0.08898327 -0.181299348\n",
+       "20 Hidden_Factor_PC1  0.851879348  0.98406483  5.18812380 -5.667832700\n",
+       "21 Hidden_Factor_PC2 -2.825894932  1.69447908  0.06854215 -4.619987817\n",
+       "22 Hidden_Factor_PC3  3.763782166 -0.80512535 -5.77247349 -3.825334825\n",
+       "23 Hidden_Factor_PC4 -1.301340188  3.15633800  2.42980902 -3.266057955\n",
+       "24 Hidden_Factor_PC5  0.556485272 -1.26228531 -3.94541314  2.110667490\n",
+       "25 Hidden_Factor_PC6 -4.493764002 -0.11490919 -2.51105454  0.278112795\n",
+       "26 Hidden_Factor_PC7  2.846210676 -0.42143392  0.34488558 -3.151865035\n",
+       "27 Hidden_Factor_PC8 -1.876624232 -9.65305786  4.25303685 -1.043104423\n",
+       "28 Hidden_Factor_PC9  3.126759781  0.48805759  5.52493678  1.428784448"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       ".list-inline {list-style: none; margin:0; padding: 0}\n",
+       ".list-inline>li {display: inline-block}\n",
+       ".list-inline>li:not(:last-child)::after {content: \"\\00b7\"; padding: 0 .5ex}\n",
+       "</style>\n",
+       "<ol class=list-inline><li>28</li><li>61</li></ol>\n"
+      ],
+      "text/latex": [
+       "\\begin{enumerate*}\n",
+       "\\item 28\n",
+       "\\item 61\n",
+       "\\end{enumerate*}\n"
+      ],
+      "text/markdown": [
+       "1. 28\n",
+       "2. 61\n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "[1] 28 61"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# ------------------------------------------------------------------\n",
     "# Example covariates file (MWE: protocol_example)\n",
@@ -135,18 +561,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "kernel": "R"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A data.table: 6 × 4</caption>\n",
+       "<thead>\n",
+       "\t<tr><th scope=col>#chr</th><th scope=col>start</th><th scope=col>end</th><th scope=col>gene_id</th></tr>\n",
+       "\t<tr><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>chr22</td><td>0</td><td>13000000</td><td>ENSG00000226444</td></tr>\n",
+       "\t<tr><td>chr22</td><td>0</td><td>13000000</td><td>ENSG00000276871</td></tr>\n",
+       "\t<tr><td>chr22</td><td>0</td><td>13000000</td><td>ENSG00000277248</td></tr>\n",
+       "\t<tr><td>chr22</td><td>0</td><td>13000000</td><td>ENSG00000279973</td></tr>\n",
+       "\t<tr><td>chr22</td><td>0</td><td>13626642</td><td>ENSG00000283023</td></tr>\n",
+       "\t<tr><td>chr22</td><td>0</td><td>13000000</td><td>ENSG00000283047</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A data.table: 6 × 4\n",
+       "\\begin{tabular}{llll}\n",
+       " \\#chr & start & end & gene\\_id\\\\\n",
+       " <chr> & <int> & <int> & <chr>\\\\\n",
+       "\\hline\n",
+       "\t chr22 & 0 & 13000000 & ENSG00000226444\\\\\n",
+       "\t chr22 & 0 & 13000000 & ENSG00000276871\\\\\n",
+       "\t chr22 & 0 & 13000000 & ENSG00000277248\\\\\n",
+       "\t chr22 & 0 & 13000000 & ENSG00000279973\\\\\n",
+       "\t chr22 & 0 & 13626642 & ENSG00000283023\\\\\n",
+       "\t chr22 & 0 & 13000000 & ENSG00000283047\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A data.table: 6 × 4\n",
+       "\n",
+       "| #chr &lt;chr&gt; | start &lt;int&gt; | end &lt;int&gt; | gene_id &lt;chr&gt; |\n",
+       "|---|---|---|---|\n",
+       "| chr22 | 0 | 13000000 | ENSG00000226444 |\n",
+       "| chr22 | 0 | 13000000 | ENSG00000276871 |\n",
+       "| chr22 | 0 | 13000000 | ENSG00000277248 |\n",
+       "| chr22 | 0 | 13000000 | ENSG00000279973 |\n",
+       "| chr22 | 0 | 13626642 | ENSG00000283023 |\n",
+       "| chr22 | 0 | 13000000 | ENSG00000283047 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  #chr  start end      gene_id        \n",
+       "1 chr22 0     13000000 ENSG00000226444\n",
+       "2 chr22 0     13000000 ENSG00000276871\n",
+       "3 chr22 0     13000000 ENSG00000277248\n",
+       "4 chr22 0     13000000 ENSG00000279973\n",
+       "5 chr22 0     13626642 ENSG00000283023\n",
+       "6 chr22 0     13000000 ENSG00000283047"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# ------------------------------------------------------------------\n",
     "# Example customized cis-window file (Optional)\n",
     "# ------------------------------------------------------------------\n",
     "# Gene-level cis-window (start/end) defining the SNP search region per gene.\n",
     "# Omit to use --window for a symmetric +/-1Mb window around each gene TSS.\n",
-    "window <- fread(\"data/mnm_genes/extended_TADB.bed\")\n",
+    "window <- fread(file.path(out,\"output/tadb/TADB_enhanced_cis.bed\"))\n",
     "head(window)"
    ]
   },
@@ -161,18 +648,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "kernel": "R"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A data.table: 6 × 2</caption>\n",
+       "<thead>\n",
+       "\t<tr><th scope=col>#id</th><th scope=col>msex</th></tr>\n",
+       "\t<tr><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;int&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>SAMPLE_001</td><td>1</td></tr>\n",
+       "\t<tr><td>SAMPLE_002</td><td>1</td></tr>\n",
+       "\t<tr><td>SAMPLE_003</td><td>1</td></tr>\n",
+       "\t<tr><td>SAMPLE_004</td><td>1</td></tr>\n",
+       "\t<tr><td>SAMPLE_005</td><td>1</td></tr>\n",
+       "\t<tr><td>SAMPLE_006</td><td>0</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A data.table: 6 × 2\n",
+       "\\begin{tabular}{ll}\n",
+       " \\#id & msex\\\\\n",
+       " <chr> & <int>\\\\\n",
+       "\\hline\n",
+       "\t SAMPLE\\_001 & 1\\\\\n",
+       "\t SAMPLE\\_002 & 1\\\\\n",
+       "\t SAMPLE\\_003 & 1\\\\\n",
+       "\t SAMPLE\\_004 & 1\\\\\n",
+       "\t SAMPLE\\_005 & 1\\\\\n",
+       "\t SAMPLE\\_006 & 0\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A data.table: 6 × 2\n",
+       "\n",
+       "| #id &lt;chr&gt; | msex &lt;int&gt; |\n",
+       "|---|---|\n",
+       "| SAMPLE_001 | 1 |\n",
+       "| SAMPLE_002 | 1 |\n",
+       "| SAMPLE_003 | 1 |\n",
+       "| SAMPLE_004 | 1 |\n",
+       "| SAMPLE_005 | 1 |\n",
+       "| SAMPLE_006 | 0 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  #id        msex\n",
+       "1 SAMPLE_001 1   \n",
+       "2 SAMPLE_002 1   \n",
+       "3 SAMPLE_003 1   \n",
+       "4 SAMPLE_004 1   \n",
+       "5 SAMPLE_005 1   \n",
+       "6 SAMPLE_006 0   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# ------------------------------------------------------------------\n",
     "# Example interaction file (Optional, for iQTL analysis)\n",
     "# ------------------------------------------------------------------\n",
     "# Provide an interaction term as a separate file via --interaction\n",
     "# when it is not already part of the covariate file.\n",
-    "int <- fread(\"data/ROSMAP_interaction_example.tsv\")\n",
+    "int <- fread(\"input/ROSMAP_interaction_example.tsv\")\n",
     "head(int)"
    ]
   },
@@ -609,9 +1157,17 @@
    "kernels": [
     [
      "Bash",
+     "calysto_bash",
      "Bash",
      "#E6EEFF",
-     ""
+     "shell"
+    ],
+    [
+     "R",
+     "ir",
+     "R",
+     "#DCDCDA",
+     "r"
     ],
     [
      "SoS",


### PR DESCRIPTION
This PR restores the example input-file preview cells in the TensorQTL association-scan notebook (code/SoS/association_scan/TensorQTL/TensorQTL.ipynb) that were removed during the earlier SoS run-command sync (#1337). These cells appear right after the ## Input Files heading and give users a concrete, runnable look at the shape of each input before they launch the pipeline.
Each restored cell uses real MWE protocol_example relative paths (under output/ and input/), so they resolve when the notebook is run from the toy-example working directory, consistent with the rest of the protocol demo. No executable pipeline code was changed: the [global], [cis_1], [cis_2], and [trans] step definitions remain byte-for-byte intact, and the notebook is valid JSON.
The restored examples cover:

Phenotype — the per-chromosome .bed.gz file list plus a single-chromosome BED preview.
Genotype — the per-chromosome PLINK file list and a merged PLINK set preview.
Covariate — the Marchenko-PC covariate matrix.
Customized cis-window (optional) — the TADB-enhanced cis-window BED used to define per-gene SNP search regions.
Interaction file (optional, for iQTL analysis) — a long-format table of sample IDs and the msex interaction term.

Note: the interaction example file (input/ROSMAP_interaction_example.tsv) is MWE data that lives in the protocol-example data tree, not in this repository — the notebook only references it, the same way the output/... example files are referenced.