### PR TITLE
Build Jupyter Book with flat notebook URLs

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -31,14 +31,20 @@ jobs:
 
       - name: Build website and manuscript
         run: |
-          # Build website
+          # Build website from a temporary flat source tree. The source notebooks
+          # stay under code/SoS, while public pages are emitted as <notebook>.html.
           rm -f pipeline/*.ipynb
-          jupyter-book build .  --path-output . --config website/_config.yml --toc website/_toc.yml
+          BOOK_SRC="$(mktemp -d)"
+          python website/build_flat_book.py --output "$BOOK_SRC"
+          jupyter-book build "$BOOK_SRC" --path-output . --config "$BOOK_SRC/website/_config.yml" --toc "$BOOK_SRC/website/_toc.yml"
+          python website/build_flat_book.py --redirects _build/html
           rsync -auzP code/images/* _build/html/_images/
           ghp-import -n -p -f _build/html
 
           # Link notebooks
-          find code -name '*.ipynb' | grep -v "ipynb_checkpoints" | xargs -I % bash -c 'ln -s ../% pipeline/$(basename %)'
+          find code/SoS -name '*.ipynb' -not -path '*/.ipynb_checkpoints/*' -print0 | while IFS= read -r -d '' notebook; do
+            ln -s "../${notebook}" "pipeline/$(basename "$notebook")"
+          done
 
           # Make manuscript
           cd website/nature_protocol

--- a/.github/workflows/dispatch_build_site.yml
+++ b/.github/workflows/dispatch_build_site.yml
@@ -27,14 +27,20 @@ jobs:
 
       - name: Build website and manuscript
         run: |
-          # Build website
+          # Build website from a temporary flat source tree. The source notebooks
+          # stay under code/SoS, while public pages are emitted as <notebook>.html.
           rm -f pipeline/*.ipynb
-          jupyter-book build .  --path-output . --config website/_config.yml --toc website/_toc.yml
+          BOOK_SRC="$(mktemp -d)"
+          python website/build_flat_book.py --output "$BOOK_SRC"
+          jupyter-book build "$BOOK_SRC" --path-output . --config "$BOOK_SRC/website/_config.yml" --toc "$BOOK_SRC/website/_toc.yml"
+          python website/build_flat_book.py --redirects _build/html
           rsync -auzP code/images/* _build/html/_images/
           ghp-import -n -p -f _build/html
 
           # Link notebooks
-          find code -name '*.ipynb' | grep -v "ipynb_checkpoints" | xargs -I % bash -c 'ln -s % pipeline/$(basename %)'
+          find code/SoS -name '*.ipynb' -not -path '*/.ipynb_checkpoints/*' -print0 | while IFS= read -r -d '' notebook; do
+            ln -s "../${notebook}" "pipeline/$(basename "$notebook")"
+          done
 
           # Make manuscript
           cd website/nature_protocol

--- a/website/_toc.yml
+++ b/website/_toc.yml
@@ -1,105 +1,106 @@
 # Table of contents
 # Learn more at https://jupyterbook.org/customize/toc.html
+# Notebook files are staged flat from code/SoS by website/build_flat_book.py.
 
 format: jb-book
 root: README
 parts:
   - caption: Getting started
     chapters:
-    - file: code/xqtl_protocol_demo.ipynb
+    - file: xqtl_protocol_demo.ipynb
   - caption: Command Generator
     chapters:
-    - file: code/commands_generator/bulk_expression_commands.ipynb
-    - file: code/commands_generator/eQTL_analysis_commands.ipynb
-    - file: code/commands_generator/apaQTL_analysis.ipynb
+    - file: bulk_expression_commands.ipynb
+    - file: eQTL_analysis_commands.ipynb
+    - file: apaQTL_analysis.ipynb
   - caption: Reference data
     chapters:
-    - file: code/reference_data/reference_data.ipynb
+    - file: reference_data.ipynb
       sections:
-      - file: code/reference_data/reference_data_preparation.ipynb
-      - file: code/reference_data/generalized_TADB.ipynb
-      - file: code/reference_data/ld_prune_reference.ipynb
-      - file: code/reference_data/rss_ld_sketch.ipynb
+      - file: reference_data_preparation.ipynb
+      - file: generalized_TADB.ipynb
+      - file: ld_prune_reference.ipynb
+      - file: rss_ld_sketch.ipynb
   - caption: Molecular Phenotypes
     chapters:
-    - file: code/molecular_phenotypes/bulk_expression.ipynb
+    - file: bulk_expression.ipynb
       sections:
-      - file: code/molecular_phenotypes/calling/RNA_calling.ipynb
-      - file: code/molecular_phenotypes/QC/bulk_expression_QC.ipynb
-      - file: code/molecular_phenotypes/QC/bulk_expression_normalization.ipynb
-      - file: code/molecular_phenotypes/snRNAseq_preprocessing.ipynb
-      - file: code/molecular_phenotypes/QC/pseudobulk_preprocessing.ipynb
-      - file: code/molecular_phenotypes/QC/pseudobulk_expression_aggregation_QC_norm.ipynb
-      - file: code/molecular_phenotypes/QC/pseudobulk_mega_expression_QC_and_normalization.ipynb
-    - file: code/molecular_phenotypes/methylation.ipynb
+      - file: RNA_calling.ipynb
+      - file: bulk_expression_QC.ipynb
+      - file: bulk_expression_normalization.ipynb
+      - file: snRNAseq_preprocessing.ipynb
+      - file: pseudobulk_preprocessing.ipynb
+      - file: pseudobulk_expression_aggregation_QC_norm.ipynb
+      - file: pseudobulk_mega_expression_QC_and_normalization.ipynb
+    - file: methylation.ipynb
       sections:
-      - file: code/molecular_phenotypes/calling/methylation_calling.ipynb
-    - file: code/molecular_phenotypes/splicing.ipynb
+      - file: methylation_calling.ipynb
+    - file: splicing.ipynb
       sections:
-      - file: code/molecular_phenotypes/calling/splicing_calling.ipynb
-      - file: code/molecular_phenotypes/QC/splicing_normalization.ipynb
-    - file: code/molecular_phenotypes/apa.ipynb
+      - file: splicing_calling.ipynb
+      - file: splicing_normalization.ipynb
+    - file: apa.ipynb
       sections:
-      - file: code/molecular_phenotypes/calling/apa_calling.ipynb
-      - file: code/molecular_phenotypes/QC/apa_impute.ipynb
+      - file: apa_calling.ipynb
+      - file: apa_impute.ipynb
   - caption: Data Pre-processing
     chapters:
-    - file: code/data_preprocessing/genotype_preprocessing.ipynb
+    - file: genotype_preprocessing.ipynb
       sections:
-      - file: code/data_preprocessing/genotype/VCF_QC.ipynb
-      - file: code/data_preprocessing/genotype/GWAS_QC.ipynb
-      - file: code/data_preprocessing/genotype/PCA.ipynb
-      - file: code/data_preprocessing/genotype/GRM.ipynb
-      - file: code/data_preprocessing/genotype/genotype_formatting.ipynb
-    - file: code/data_preprocessing/phenotype_preprocessing.ipynb
+      - file: VCF_QC.ipynb
+      - file: GWAS_QC.ipynb
+      - file: PCA.ipynb
+      - file: GRM.ipynb
+      - file: genotype_formatting.ipynb
+    - file: phenotype_preprocessing.ipynb
       sections:
-      - file: code/data_preprocessing/phenotype/gene_annotation.ipynb
-      - file: code/data_preprocessing/phenotype/phenotype_imputation.ipynb
-      - file: code/data_preprocessing/phenotype/phenotype_formatting.ipynb
-    - file: code/data_preprocessing/covariate_preprocessing.ipynb
+      - file: gene_annotation.ipynb
+      - file: phenotype_imputation.ipynb
+      - file: phenotype_formatting.ipynb
+    - file: covariate_preprocessing.ipynb
       sections:
-      - file: code/data_preprocessing/covariate/covariate_formatting.ipynb
-      - file: code/data_preprocessing/covariate/covariate_hidden_factor.ipynb
+      - file: covariate_formatting.ipynb
+      - file: covariate_hidden_factor.ipynb
   - caption: QTL Association Testing
     chapters:
-    - file: code/association_scan/qtl_association_testing.ipynb
+    - file: qtl_association_testing.ipynb
       sections:
-      - file: code/association_scan/TensorQTL/TensorQTL.ipynb
-      - file: code/association_scan/quantile_models/qr_and_twas.ipynb
-    - file: code/association_scan/qtl_association_postprocessing.ipynb
+      - file: TensorQTL.ipynb
+      - file: qr_and_twas.ipynb
+    - file: qtl_association_postprocessing.ipynb
   - caption: Multivariate Mixture Model
     chapters:
-    - file: code/multivariate_genome/multivariate_mixture_vignette.ipynb
+    - file: multivariate_mixture_vignette.ipynb
       sections:
-      - file: code/multivariate_genome/MASH/mash_preprocessing.ipynb
-      - file: code/multivariate_genome/MASH/mixture_prior.ipynb
-      - file: code/multivariate_genome/MASH/mash_fit.ipynb
-      - file: code/multivariate_genome/MASH/mash_posterior.ipynb
+      - file: mash_preprocessing.ipynb
+      - file: mixture_prior.ipynb
+      - file: mash_fit.ipynb
+      - file: mash_posterior.ipynb
   - caption: Multiomics Regression Models
     chapters:
-    - file: code/mnm_analysis/mnm_miniprotocol.ipynb
+    - file: mnm_miniprotocol.ipynb
       sections:
-      - file: code/mnm_analysis/univariate_fine_mapping_twas_vignette.ipynb
-      - file: code/mnm_analysis/multivariate_multigene_fine_mapping_vignette.ipynb
-      - file: code/mnm_analysis/univariate_fine_mapping_fsusie_vignette.ipynb
-      - file: code/mnm_analysis/multivariate_fine_mapping_vignette.ipynb
-      - file: code/mnm_analysis/summary_stats_finemapping_vignette.ipynb
-      - file: code/mnm_analysis/mnm_methods/mnm_regression.ipynb
-      - file: code/mnm_analysis/mnm_methods/rss_analysis.ipynb
-    - file: code/mnm_analysis/mnm_postprocessing.ipynb
+      - file: univariate_fine_mapping_twas_vignette.ipynb
+      - file: multivariate_multigene_fine_mapping_vignette.ipynb
+      - file: univariate_fine_mapping_fsusie_vignette.ipynb
+      - file: multivariate_fine_mapping_vignette.ipynb
+      - file: summary_stats_finemapping_vignette.ipynb
+      - file: mnm_regression.ipynb
+      - file: rss_analysis.ipynb
+    - file: mnm_postprocessing.ipynb
   - caption: GWAS Integration
     chapters:
-    - file: code/pecotmr_integration/SuSiE_enloc.ipynb
-    - file: code/pecotmr_integration/twas_ctwas.ipynb
-    - file: code/mnm_analysis/mnm_methods/colocboost.ipynb
+    - file: SuSiE_enloc.ipynb
+    - file: twas_ctwas.ipynb
+    - file: colocboost.ipynb
   - caption: Enrichment and Validation
     chapters:
-    - file: code/enrichment/eoo_enrichment.ipynb
-    - file: code/enrichment/gsea.ipynb
-    - file: code/enrichment/gregor.ipynb
-    - file: code/enrichment/sldsc_enrichment.ipynb
+    - file: eoo_enrichment.ipynb
+    - file: gsea.ipynb
+    - file: gregor.ipynb
+    - file: sldsc_enrichment.ipynb
   - caption: xQTL Modifier Score
     chapters:
-    - file: code/xqtl_modifier_score/ems_training.ipynb
-    - file: code/xqtl_modifier_score/ems_prediction.ipynb
+    - file: ems_training.ipynb
+    - file: ems_prediction.ipynb
 

--- a/website/build_flat_book.py
+++ b/website/build_flat_book.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Stage xQTL protocol notebooks as a flat Jupyter Book source tree.
+
+The repository keeps notebooks under code/SoS/<topic>/, but the public site
+uses flat page names such as reference_data.html. This script creates a
+temporary build source with notebook basenames at the root, rewrites temporary
+page-to-page links to those flat names, and can emit compatibility redirects for
+older code/... URLs after the HTML build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlsplit, urlunsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = REPO_ROOT / "code" / "SoS"
+WEBSITE_ROOT = REPO_ROOT / "website"
+SITE_NETLOC = "statfungen.github.io"
+SITE_PREFIX = "/xqtl-protocol/"
+MARKDOWN_LINK_RE = re.compile(r"(!?\[[^\]]*\]\()([^)]*)(\))")
+HTML_SRC_RE = re.compile(r"(\bsrc=[\"'])([^\"']+)([\"'])", re.IGNORECASE)
+TOC_FILE_RE = re.compile(r"\bfile:\s*([^\s#]+)")
+
+
+def iter_files(root: Path, pattern: str):
+    for path in sorted(root.rglob(pattern)):
+        if ".ipynb_checkpoints" not in path.parts and path.is_file():
+            yield path
+
+
+def unique_by_basename(paths, label: str):
+    seen = {}
+    duplicates = {}
+    for path in paths:
+        name = path.name
+        if name in seen:
+            duplicates.setdefault(name, [seen[name]]).append(path)
+        else:
+            seen[name] = path
+    if duplicates:
+        lines = [f"Duplicate {label} basenames are not compatible with flat URLs:"]
+        for name, dupes in sorted(duplicates.items()):
+            rels = ", ".join(str(p.relative_to(SOURCE_ROOT)) for p in dupes)
+            lines.append(f"  {name}: {rels}")
+        raise SystemExit("\n".join(lines))
+    return seen
+
+
+def notebook_index():
+    notebooks = list(iter_files(SOURCE_ROOT, "*.ipynb"))
+    return unique_by_basename(notebooks, "notebook")
+
+
+def asset_index():
+    assets = [
+        path
+        for path in iter_files(SOURCE_ROOT, "*")
+        if path.suffix != ".ipynb" and path.name != "README.md"
+    ]
+    by_name = {}
+    for path in assets:
+        by_name.setdefault(path.name, path)
+    return assets, by_name
+
+
+def parse_toc_files():
+    toc = WEBSITE_ROOT / "_toc.yml"
+    files = []
+    for match in TOC_FILE_RE.finditer(toc.read_text(encoding="utf-8")):
+        value = match.group(1).strip('"\'')
+        if value.endswith(".ipynb"):
+            files.append(value)
+    return files
+
+
+def copy_or_link(src: Path, dst: Path):
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists() or dst.is_symlink():
+        return
+    try:
+        dst.symlink_to(src.resolve())
+    except OSError:
+        shutil.copy2(src, dst)
+
+
+def flat_page_for_path(path: str, notebooks: dict[str, Path], assets: dict[str, Path]):
+    if not path or path.startswith("#"):
+        return None
+    name = PurePosixPath(path).name
+    if not name:
+        return None
+
+    suffix = PurePosixPath(name).suffix
+    stem = PurePosixPath(name).stem
+    if suffix == ".ipynb" and name in notebooks:
+        return name
+    if suffix == ".html" and f"{stem}.ipynb" in notebooks:
+        return f"{stem}.html"
+    if not suffix and f"{name}.ipynb" in notebooks:
+        return f"{name}.html"
+    if suffix and name in assets:
+        return name
+    return None
+
+
+def rewrite_url(url: str, notebooks: dict[str, Path], assets: dict[str, Path]):
+    if not url or url.startswith("#") or url.startswith("mailto:"):
+        return url
+    parsed = urlsplit(url)
+
+    if parsed.scheme and not (
+        parsed.scheme in {"http", "https"}
+        and parsed.netloc == SITE_NETLOC
+        and parsed.path.startswith(SITE_PREFIX)
+    ):
+        return url
+
+    path = parsed.path
+    if parsed.netloc == SITE_NETLOC and path.startswith(SITE_PREFIX):
+        path = path.removeprefix(SITE_PREFIX)
+
+    flat = flat_page_for_path(path, notebooks, assets)
+    if not flat:
+        return url
+
+    if parsed.netloc == SITE_NETLOC:
+        return urlunsplit((parsed.scheme, parsed.netloc, SITE_PREFIX + flat, parsed.query, parsed.fragment))
+    return urlunsplit(("", "", flat, parsed.query, parsed.fragment))
+
+
+def rewrite_markdown(text: str, notebooks: dict[str, Path], assets: dict[str, Path]):
+    def replace_markdown(match):
+        return f"{match.group(1)}{rewrite_url(match.group(2), notebooks, assets)}{match.group(3)}"
+
+    def replace_src(match):
+        return f"{match.group(1)}{rewrite_url(match.group(2), notebooks, assets)}{match.group(3)}"
+
+    text = MARKDOWN_LINK_RE.sub(replace_markdown, text)
+    text = HTML_SRC_RE.sub(replace_src, text)
+    return text
+
+
+def write_flat_notebook(src: Path, dst: Path, notebooks: dict[str, Path], assets: dict[str, Path]):
+    nb = json.loads(src.read_text(encoding="utf-8"))
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "markdown":
+            continue
+        source = cell.get("source", [])
+        if isinstance(source, list):
+            text = "".join(source)
+            cell["source"] = rewrite_markdown(text, notebooks, assets).splitlines(keepends=True)
+        elif isinstance(source, str):
+            cell["source"] = rewrite_markdown(source, notebooks, assets)
+    dst.write_text(json.dumps(nb, ensure_ascii=False, indent=1) + "\n", encoding="utf-8")
+
+
+def stage_book(output: Path):
+    notebooks = notebook_index()
+    assets, assets_by_name = asset_index()
+    toc_files = parse_toc_files()
+
+    missing = [name for name in toc_files if name not in notebooks]
+    nested = [name for name in toc_files if "/" in name or "\\" in name]
+    if nested:
+        raise SystemExit("TOC notebook entries should be flat basenames only:\n  " + "\n  ".join(nested))
+    if missing:
+        raise SystemExit("TOC notebooks were not found under code/SoS:\n  " + "\n  ".join(missing))
+
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+
+    shutil.copy2(REPO_ROOT / "README.md", output / "README.md")
+    website_out = output / "website"
+    website_out.mkdir()
+    for name in ["_config.yml", "_toc.yml", "references.bib", "xqtl_wf.png", "xqtl_wf.svg"]:
+        src = WEBSITE_ROOT / name
+        if src.exists():
+            shutil.copy2(src, website_out / name)
+
+    for asset in assets:
+        rel = asset.relative_to(SOURCE_ROOT)
+        copy_or_link(asset, output / rel)
+        copy_or_link(asset, output / asset.name)
+
+    for name, src in notebooks.items():
+        write_flat_notebook(src, output / name, notebooks, assets_by_name)
+
+    print(f"Staged {len(notebooks)} notebooks as flat book sources in {output}")
+
+
+def redirect_document(target: str):
+    escaped = html.escape(target, quote=True)
+    js_target = json.dumps(target)
+    return (
+        "<!doctype html>\n"
+        "<meta charset=\"utf-8\">\n"
+        "<title>Redirecting...</title>\n"
+        f"<meta http-equiv=\"refresh\" content=\"0; url={escaped}\">\n"
+        f"<link rel=\"canonical\" href=\"{escaped}\">\n"
+        f"<script>location.replace({js_target});</script>\n"
+        f"<p>Redirecting to <a href=\"{escaped}\">{escaped}</a>.</p>\n"
+    )
+
+
+def write_redirect(path: Path, target: Path, html_root: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rel_target = os.path.relpath(target, path.parent).replace(os.sep, "/")
+    path.write_text(redirect_document(rel_target), encoding="utf-8")
+
+
+def write_redirects(html_root: Path):
+    notebooks = notebook_index()
+    toc_files = parse_toc_files()
+    count = 0
+    for name in toc_files:
+        src = notebooks[name]
+        rel_html = src.relative_to(SOURCE_ROOT).with_suffix(".html")
+        target = html_root / f"{Path(name).stem}.html"
+        for old_prefix in ("code", "code/SoS"):
+            redirect_path = html_root / old_prefix / rel_html
+            write_redirect(redirect_path, target, html_root)
+            count += 1
+    print(f"Wrote {count} compatibility redirects under {html_root}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, help="temporary flat Jupyter Book source directory to create")
+    parser.add_argument("--redirects", type=Path, help="built HTML directory where old code/... redirects should be written")
+    args = parser.parse_args(argv)
+
+    if not args.output and not args.redirects:
+        parser.error("provide --output, --redirects, or both")
+    if args.output:
+        stage_book(args.output)
+    if args.redirects:
+        write_redirects(args.redirects)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- flatten website/_toc.yml notebook entries to bare notebook filenames
- stage code/SoS notebooks into a temporary flat Jupyter Book source tree during Actions builds
- rewrite temporary internal page links and generate compatibility redirects for old code/... and code/SoS/... URLs

## Validation
- PYTHONPYCACHEPREFIX=/private/tmp/xqtl-pycache python -m py_compile website/build_flat_book.py
- python website/build_flat_book.py --output /private/tmp/xqtl-flat-book-final
- python website/build_flat_book.py --redirects /private/tmp/xqtl-redirect-final
- YAML parsing for both workflows, website/_toc.yml, and website/_config.yml
- git diff --check

Note: a full local jupyter-book build was not run because jupyter-book is not installed in this local environment; GitHub Actions installs jupyter-book==1.0.4 before building.