### PR TITLE
Modified the definition of cis window to match the real strategy used

### DIFF
--- a/code/SoS/reference_data/generalized_TADB.ipynb
+++ b/code/SoS/reference_data/generalized_TADB.ipynb
@@ -6,17 +6,7 @@
    "metadata": {
     "kernel": "SoS"
    },
-   "source": [
-    "# Generation of Topologically Associated Domains and their Boundaries\n",
-    "\n",
-    "## Description\n",
-    "\n",
-    "This notebook builds **TAD boundaries (TADBs)** and TADB-enhanced cis windows from tissue/brain TAD calls. It runs in two conceptual stages: (i) *manage TAD redundancy* by recursively merging overlapping specific TADs (those whose overlap exceeds a cutoff) into a smaller set of generalized TADs, and (ii) *generate TADB-enhanced cis windows and extended TADBs* by deriving boundaries from the generalized + specific TADs and joining them with gene coordinates to produce per-gene cis windows.\n",
-    "\n",
-    "During fine mapping we often use a cis window (up & downstream 1Mb of the start of a gene) as the fine-mapping region. That choice lacks a biological justification, so here we instead extend regions using TAD structure, producing both extended TADBs and TADB-enhanced cis windows since each serves a different goal. Genes within each TADB are extended by their 1Mb cis windows and the outermost boundary is taken, yielding roughly 1,381 TADBs that can serve as functional units for epigenetic analysis.\n",
-    "\n",
-    "> **Synthetic-data note.** This minimal working example runs on a small synthetic set of chr22 TAD blocks (`protocol_example.brain_TADs.txt`) and a chr22 gene table (`protocol_example.gene_start_end.tsv`, derived from the protocol gene-model GTF). It is for demonstration only and does not reproduce a full genome-wide TADB build.\n"
-   ]
+   "source": "# Generation of Topologically Associated Domains and their Boundaries\n\n## Description\n\nThis notebook builds **TAD boundaries (TADBs)** and TADB-enhanced cis windows from tissue/brain TAD calls. It runs in two conceptual stages: (i) *manage TAD redundancy* by recursively merging overlapping specific TADs (those whose overlap exceeds a cutoff) into a smaller set of generalized TADs, and (ii) *generate TADB-enhanced cis windows and extended TADBs* by deriving boundaries from the generalized + specific TADs and joining them with gene coordinates to produce per-gene cis windows.\n\nDuring fine mapping we often use a cis window (the gene body extended by 1Mb up- and downstream, i.e. gene start − 1Mb to gene end + 1Mb) as the fine-mapping region. That choice lacks a biological justification, so here we instead extend regions using TAD structure, producing both extended TADBs and TADB-enhanced cis windows since each serves a different goal. Genes within each TADB are extended by their 1Mb cis windows and the outermost boundary is taken, yielding roughly 1,381 TADBs that can serve as functional units for epigenetic analysis.\n\n> **Synthetic-data note.** This minimal working example runs on a small synthetic set of chr22 TAD blocks (`protocol_example.brain_TADs.txt`) and a chr22 gene table (`protocol_example.gene_start_end.tsv`, derived from the protocol gene-model GTF). It is for demonstration only and does not reproduce a full genome-wide TADB build."
   },
   {
    "cell_type": "markdown",
@@ -167,11 +157,7 @@
    "metadata": {
     "kernel": "SoS"
    },
-   "source": [
-    "#### Compare TADB and cis windows\n",
-    "\n",
-    "Each TADB covers many genes. For fine-mapping, each gene is assigned a 1Mb cis window (2Mb total), so the next step checks whether the TADBs fully cover the cis windows of the genes inside them. Verifying that every gene is covered by a TADB confirms the TADBs are correct, since they should span the whole genome. The only genes in the full gene list not covered by a TADB are on chromosome Y, MT, or are ERCC spike-ins; these are expected to be absent because the TAD data does not include them. A value of 0 marks a cis window not fully covered by the TADB its gene lies in: even after constructing the TADBs, many genes still have a 1Mb cis window (2Mb total) that extends beyond its TADB region."
-   ]
+   "source": "#### Compare TADB and cis windows\n\nEach TADB covers many genes. For fine-mapping, each gene is assigned a cis window (the gene body ± 1Mb, i.e. gene start − 1Mb to gene end + 1Mb), so the next step checks whether the TADBs fully cover the cis windows of the genes inside them. Verifying that every gene is covered by a TADB confirms the TADBs are correct, since they should span the whole genome. The only genes in the full gene list not covered by a TADB are on chromosome Y, MT, or are ERCC spike-ins; these are expected to be absent because the TAD data does not include them. A value of 0 marks a cis window not fully covered by the TADB its gene lies in: even after constructing the TADBs, many genes still have a cis window (gene body ± 1Mb) that extends beyond its TADB region."
   },
   {
    "cell_type": "markdown",
@@ -179,11 +165,7 @@
    "metadata": {
     "kernel": "SoS"
    },
-   "source": [
-    "#### Construct TADB-enhanced cis windows and extended TADBs\n",
-    "\n",
-    "For each gene, its 1Mb upstream/downstream window (2Mb total) and the TADB it falls in are combined, extending the region outward to the smaller start and the larger end of the two. This yields one extended cis window per gene, most with a length close to or larger than the original 2Mb window, so that every gene maps to an extended cis window and none is left uncovered. Compared with the TADB-enhanced cis window, the extended TADB allows a single gene to belong to multiple extended regions."
-   ]
+   "source": "#### Construct TADB-enhanced cis windows and extended TADBs\n\nFor each gene, its cis window (the gene body ± 1Mb, i.e. gene start − 1Mb to gene end + 1Mb) and the TADB it falls in are combined, extending the region outward to the smaller start and the larger end of the two. This yields one extended cis window per gene, most with a length close to or larger than the original cis window, so that every gene maps to an extended cis window and none is left uncovered. Compared with the TADB-enhanced cis window, the extended TADB allows a single gene to belong to multiple extended regions."
   },
   {
    "cell_type": "code",
@@ -559,17 +541,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "SoS",
-   "language": "sos",
-   "name": "sos"
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": "sos",
-   "file_extension": ".sos",
-   "mimetype": "text/x-sos",
-   "name": "sos",
-   "nbconvert_exporter": "sos_notebook.converter.SoS_Exporter",
-   "pygments_lexer": "sos"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
   },
   "sos": {
    "kernels": [


### PR DESCRIPTION
Checked: the cis window is defined by gene body (TSS − 1Mb to TES + 1Mb), not by TSS alone. This PR updates the docs to reflect the definition the code actually uses.